### PR TITLE
Reset navbar panel cache when selecting navbar buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Before adding new panel logic, prefer shared building blocks first:
 - Track preference persistence: `src/hooks/useTrackPreferences.js`
 - Image fallback handling: `src/hooks/useImageErrorFallback.js`
 - Settings sync listeners: `src/hooks/useBreezyfinSettingsSync.js`
+- Scroll restoration + cached panel scroll state: `src/hooks/useScrollerScrollMemory.js`
+  - `useScrollerScrollMemory()` for `Scroller` restore/save wiring
+  - `useCachedScrollTopState()` for normalized cached scrollTop state
 - Reusable media-card overlays: `src/components/MediaCardStatusOverlay.js`
 - Shared toolbar focus helper: `src/utils/toolbarFocus.js`
 - Shared home row order constant: `src/constants/homeRows.js`

--- a/appinfo.json
+++ b/appinfo.json
@@ -1,6 +1,6 @@
 {
     "id": "com.breezyfin.app",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "vendor": "botagas",
     "type": "web",
     "main": "index.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "breezyfin",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "Jellyfin client for LG webOS TVs, built with Enact Sandstone.",
 	"author": "",
 	"main": "src/index.js",

--- a/src/hooks/useScrollerScrollMemory.js
+++ b/src/hooks/useScrollerScrollMemory.js
@@ -1,0 +1,83 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+export const normalizeScrollTop = (value) => {
+	const numericValue = Number(value);
+	if (!Number.isFinite(numericValue) || numericValue <= 0) return 0;
+	return numericValue;
+};
+
+const schedule = (callback) => {
+	if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+		window.requestAnimationFrame(callback);
+		return;
+	}
+	callback();
+};
+
+export const useCachedScrollTopState = (cachedScrollTop = 0) => {
+	const [scrollTop, setScrollTop] = useState(() => normalizeScrollTop(cachedScrollTop));
+
+	useEffect(() => {
+		const nextTop = normalizeScrollTop(cachedScrollTop);
+		setScrollTop((currentTop) => (Math.abs(currentTop - nextTop) < 1 ? currentTop : nextTop));
+	}, [cachedScrollTop]);
+
+	return [scrollTop, setScrollTop];
+};
+
+export const useScrollerScrollMemory = ({
+	isActive = false,
+	scrollTop = 0,
+	onScrollTopChange = null
+} = {}) => {
+	const scrollToRef = useRef(null);
+	const targetScrollTopRef = useRef(normalizeScrollTop(scrollTop));
+	const lastKnownScrollTopRef = useRef(null);
+
+	useEffect(() => {
+		targetScrollTopRef.current = normalizeScrollTop(scrollTop);
+	}, [scrollTop]);
+
+	const applyScrollRestore = useCallback((force = false) => {
+		if (!isActive) return;
+		if (typeof scrollToRef.current !== 'function') return;
+
+		const targetTop = targetScrollTopRef.current;
+		const lastTop = lastKnownScrollTopRef.current;
+		if (!force && lastTop !== null && Math.abs(targetTop - lastTop) < 1) return;
+
+		if (targetTop <= 0) {
+			scrollToRef.current({align: 'top', animate: false});
+		} else {
+			scrollToRef.current({position: {y: targetTop}, animate: false});
+		}
+		lastKnownScrollTopRef.current = targetTop;
+	}, [isActive]);
+
+	useEffect(() => {
+		if (!isActive) {
+			lastKnownScrollTopRef.current = null;
+			return;
+		}
+		schedule(() => applyScrollRestore());
+	}, [applyScrollRestore, isActive, scrollTop]);
+
+	const captureScrollTo = useCallback((fn) => {
+		scrollToRef.current = fn;
+		if (!isActive || typeof fn !== 'function') return;
+		schedule(() => applyScrollRestore());
+	}, [applyScrollRestore, isActive]);
+
+	const handleScrollStop = useCallback((event) => {
+		const nextTop = normalizeScrollTop(event?.scrollTop);
+		lastKnownScrollTopRef.current = nextTop;
+		if (typeof onScrollTopChange === 'function') {
+			onScrollTopChange(nextTop);
+		}
+	}, [onScrollTopChange]);
+
+	return {
+		captureScrollTo,
+		handleScrollStop
+	};
+};

--- a/src/services/jellyfinService.js
+++ b/src/services/jellyfinService.js
@@ -1072,9 +1072,9 @@ class JellyfinService {
 		});
 	}
 
-	async search(searchTerm, itemTypes = null, limit = 25) {
+	async search(searchTerm, itemTypes = null, limit = 25, startIndex = 0) {
 		try {
-			let url = `${this.serverUrl}/Users/${this.userId}/Items?searchTerm=${encodeURIComponent(searchTerm)}&limit=${limit}&recursive=true&fields=Overview,PrimaryImageAspectRatio,BackdropImageTags,ImageTags,PrimaryImageTag,SeriesPrimaryImageTag,SeriesName,ParentIndexNumber,IndexNumber,UserData&imageTypeLimit=1&enableTotalRecordCount=false`;
+			let url = `${this.serverUrl}/Users/${this.userId}/Items?searchTerm=${encodeURIComponent(searchTerm)}&limit=${limit}&startIndex=${Math.max(0, Number(startIndex) || 0)}&recursive=true&fields=Overview,PrimaryImageAspectRatio,BackdropImageTags,ImageTags,PrimaryImageTag,SeriesPrimaryImageTag,SeriesName,ParentIndexNumber,IndexNumber,UserData&imageTypeLimit=1&enableTotalRecordCount=false`;
 
 			if (itemTypes && itemTypes.length > 0) {
 				const types = Array.isArray(itemTypes) ? itemTypes.join(',') : itemTypes;

--- a/src/views/media-details-styles/_media-details-base.less
+++ b/src/views/media-details-styles/_media-details-base.less
@@ -13,6 +13,8 @@
 	--bf-media-details-base-rgb: 18, 18, 18;
 	--bf-media-details-control-radius: 0.9rem;
 	--bf-media-details-episode-radius: 1.75rem;
+	--bf-md-hero-top-padding: 0.5rem;
+	--bf-md-hero-top-padding-elegant: 26vh;
 	min-height: 100vh;
 	background-color: rgb(var(--bf-media-details-base-rgb));
 	background: linear-gradient(
@@ -21,6 +23,11 @@
 		rgb(var(--bf-media-details-base-rgb)) 120px
 	);
 	position: relative;
+}
+
+.episodeDetailsMode {
+	--bf-md-hero-top-padding: 0rem;
+	--bf-md-hero-top-padding-elegant: 18vh;
 }
 
 .mdControlSurface(@bg; @border; @radius: 999px) {
@@ -127,9 +134,30 @@
 }
 
 .content {
-	padding: 1rem 48px calc(120px + var(--bf-panel-content-bottom-padding, 4rem)) 48px;
+	--bf-md-content-top-padding: 1rem;
+	padding: var(--bf-md-content-top-padding) 48px calc(120px + var(--bf-panel-content-bottom-padding, 4rem)) 48px;
 	position: relative;
 	z-index: 2;
+}
+
+.firstSection {
+	min-height: calc(100vh - var(--bf-md-content-top-padding, 1rem));
+	max-height: calc(100vh - var(--bf-md-content-top-padding, 1rem));
+	height: calc(100vh - var(--bf-md-content-top-padding, 1rem));
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.firstSection .detailsHeadingStack {
+	flex: 0 0 auto;
+}
+
+.firstSection .introSection {
+	flex: 1 1 auto;
+	min-height: 0 !important;
+	max-height: none !important;
+	height: auto !important;
 }
 
 .detailsHeadingStack {
@@ -212,30 +240,26 @@
 	min-height: calc(100vh - var(--bf-details-topbar-height, 2.35rem) - var(--bf-details-topbar-gap, 0.65rem) - 1rem);
 	display: flex;
 	flex-direction: column;
+	justify-content: flex-end;
 }
 
 .introContent {
 	flex: 0 0 auto;
 }
 
-.introSpacer {
-	flex: 1 1 auto;
-	min-height: clamp(4.8rem, 13vh, 10rem);
-	pointer-events: none;
-}
-
 .introHeaderRow {
 	display: flex;
 	align-items: flex-start;
 	justify-content: space-between;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
 	gap: 1rem 1.4rem;
 }
 
 .introCredits {
-	flex: 0 1 min(36rem, 46%);
-	min-width: 16rem;
-	margin-top: clamp(0.8rem, 2.1vh, 1.3rem);
+	flex: 0 0 min(30rem, 34%);
+	max-width: min(30rem, 34%);
+	min-width: 14rem;
+	margin-top: 0;
 	padding: 0.2rem 0 0 0.5rem;
 	display: flex;
 	flex-direction: column;
@@ -245,6 +269,12 @@
 }
 
 .creditLine {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	row-gap: 0.08rem;
+	text-align: right;
+	width: 100%;
 	margin: 0;
 	font-size: 0.83em;
 	line-height: 1.35;
@@ -254,12 +284,25 @@
 }
 
 .creditLabel {
+	display: block;
+	min-width: 0;
+	text-align: right;
 	font-weight: 700;
 	color: rgba(243, 249, 255, 0.96);
 }
 
 .creditNames {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	text-align: right;
+	white-space: normal;
 	color: rgba(219, 230, 245, 0.88);
+}
+
+.creditNameItem {
+	display: block;
+	line-height: 1.25;
 }
 
 .contentSection {
@@ -275,20 +318,27 @@
 	align-items: flex-start;
 	justify-content: flex-start;
 	min-height: 1rem;
-	max-width: 80vw;
+	max-width: 70vw;
 }
 
 .headerLogo {
 	display: block;
 	max-width: 100%;
-	max-height: 8rem;
+	max-height: 10rem;
 	width: auto;
 	object-fit: contain;
 }
 
 .pageHeader {
-	padding: 2.1rem 0 1.5rem;
+	flex: 1 1 auto;
+	min-width: 0;
+	max-width: 60vw;
+	padding: var(--bf-md-hero-top-padding) 0 1.5rem;
 	margin-bottom: 24px;
+}
+
+.episodeDetailsMode .introSection {
+	min-height: calc(100vh - var(--bf-details-topbar-height, 2.35rem) - var(--bf-details-topbar-gap, 0.65rem) - 2.8rem);
 }
 
 .pageHeaderTitle {

--- a/src/views/media-details-styles/_media-details-elegant.less
+++ b/src/views/media-details-styles/_media-details-elegant.less
@@ -29,6 +29,7 @@
 }
 
 .contentElegant {
+	--bf-md-content-top-padding: 0.25rem;
 	padding-top: 0.25rem;
 }
 
@@ -37,8 +38,16 @@
 }
 
 .contentElegant .pageHeader {
-	padding-top: 26vh;
+	padding-top: var(--bf-md-hero-top-padding-elegant, 26vh);
 	margin-bottom: 1rem;
+}
+
+.episodeDetailsMode .contentElegant .pageHeader {
+	padding-top: var(--bf-md-hero-top-padding-elegant, 16vh);
+}
+
+.episodeDetailsMode .introSectionElegant {
+	min-height: calc(100vh - var(--bf-details-topbar-height, 2.35rem) - var(--bf-details-topbar-gap, 0.65rem) - 1.8rem);
 }
 
 :global([data-bf-nav-theme='elegant']) {

--- a/src/views/search-panel-styles/_search-panel-base.less
+++ b/src/views/search-panel-styles/_search-panel-base.less
@@ -173,6 +173,12 @@
 	min-height: 0;
 }
 
+.loadingMore {
+	display: flex;
+	justify-content: center;
+	padding: 1rem 0 1.75rem;
+}
+
 .emptyState {
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
Summary
- clear cached panel states when navigating via the navbar so panels like Home, Search, Favorites, and Settings always load fresh when entered directly
- update helpers info in README
- bump the version metadata to v0.1.4 to reflect the new helper workflow