### PR TITLE
hotfix: Media Details Panel return button caused a loop due to state caching races

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -732,7 +732,7 @@ const App = (props) => {
 
 	panelChildren.push(
 		<MediaDetailsPanel
-			key="details"
+			key={`details-${selectedItem?.Id || 'none'}`}
 			isActive={currentView === 'details'}
 			item={selectedItem}
 			onBack={navigateBackFromDetails}


### PR DESCRIPTION
Introduce keys to better distinguish series/episode pages in Media Details Panel.