### PR TITLE
Update docs and front-end helpers

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -9,6 +9,7 @@ This guide covers shared UI components in `src/components/`.
 - Keep event contracts explicit (`onClick`, `onClose`, `onSelect`, etc.).
 - Keep style overrides token-driven (`var(--bf-...)`) and compatible with Classic/Elegant themes.
 - For larger shared components, prefer local decomposition folders (for example `src/components/toolbar/`) to keep root files focused on orchestration.
+- Reuse shared feedback primitives (for example `src/components/BreezyToast.js`) instead of panel-specific toast styling/markup.
 
 ## Styling
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -76,6 +76,7 @@ Other shared utilities:
 - Shared home row order constant: `src/constants/homeRows.js`
 - Shared poster card class helper: `src/utils/posterCardClassProps.js`
 - Shared player view helpers: `src/views/player-panel/utils/playerPanelHelpers.js`
+  - includes `getPlayerHeaderTitle(item)` for `SxEx: Title` episode header formatting
 - Shared episode next/previous helpers: `src/views/player-panel/utils/episodeNavigation.js`
 - Shared media details formatting/image helpers: `src/views/media-details-panel/utils/mediaDetailsHelpers.js`
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -76,7 +76,6 @@ Other shared utilities:
 - Shared home row order constant: `src/constants/homeRows.js`
 - Shared poster card class helper: `src/utils/posterCardClassProps.js`
 - Shared player view helpers: `src/views/player-panel/utils/playerPanelHelpers.js`
-  - includes `getPlayerHeaderTitle(item)` for `SxEx: Title` episode header formatting
 - Shared episode next/previous helpers: `src/views/player-panel/utils/episodeNavigation.js`
 - Shared media details formatting/image helpers: `src/views/media-details-panel/utils/mediaDetailsHelpers.js`
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -27,8 +27,10 @@ This document is the detailed developer guide for architecture patterns, shared 
 - Map lookups by id/key: `src/hooks/useMapById.js`
 - Item metadata fetch/state: `src/hooks/useItemMetadata.js`
 - Toast lifecycle: `src/hooks/useToastMessage.js`
+- Shared toast UI primitive (Player/Media Details/Settings): `src/components/BreezyToast.js`
 - Track preference persistence: `src/hooks/useTrackPreferences.js`
 - Image fallback handling: `src/hooks/useImageErrorFallback.js`
+- Runtime platform/playback capability detection + cache controls: `src/utils/platformCapabilities.js`
 - Player remote/media-key handler: `src/views/player-panel/hooks/usePlayerKeyboardShortcuts.js`
 - Player video load/session orchestration: `src/views/player-panel/hooks/usePlayerVideoLoader.js`
 - Player skip/prompt state machine: `src/views/player-panel/hooks/usePlayerSkipOverlayState.js`

--- a/HELPERS.md
+++ b/HELPERS.md
@@ -417,7 +417,7 @@ useToastMessage({ durationMs = 2000, fadeOutMs = 0 })
 ### Player and media detail helpers
 - `src/views/player-panel/utils/playerPanelHelpers.js`
   - `formatPlaybackTime(seconds)`
-  - `getPlayerHeaderTitle(item)` (builds `SxEx: Title` episode label)
+  - `getPlayerHeaderTitle(item)` (builds formatted episode title with season/episode prefix when available)
   - `getPlayerTrackLabel(track)`
   - `getSkipSegmentLabel(segmentType, hasNextEpisode?)`
   - `getPlayerErrorBackdropUrl(item, imageApi)`

--- a/HELPERS.md
+++ b/HELPERS.md
@@ -417,6 +417,7 @@ useToastMessage({ durationMs = 2000, fadeOutMs = 0 })
 ### Player and media detail helpers
 - `src/views/player-panel/utils/playerPanelHelpers.js`
   - `formatPlaybackTime(seconds)`
+  - `getPlayerHeaderTitle(item)` (builds `SxEx: Title` episode label)
   - `getPlayerTrackLabel(track)`
   - `getSkipSegmentLabel(segmentType, hasNextEpisode?)`
   - `getPlayerErrorBackdropUrl(item, imageApi)`

--- a/HELPERS.md
+++ b/HELPERS.md
@@ -30,6 +30,7 @@ This file documents shared hooks/helpers used across Breezyfin so panel code sta
 | Reusable toast lifecycle | `useToastMessage` |
 | Reusable image fallback behavior | `useImageErrorFallback` |
 | Audio/subtitle preference pick + persist | `useTrackPreferences` |
+| Runtime playback/platform capability snapshot + cache controls | `getRuntimePlatformCapabilities` / `setRuntimeCapabilityProbeRefreshDays` / `refreshRuntimePlatformCapabilities` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </h1>
 
 Breezyfin is a Jellyfin client for LG webOS TVs, built with Enact Sandstone.
-It focuses on TV-first navigation, themeable UI, and resilient playback handling for webOS constraints.
+It focuses on TV-first navigation (best suited for usage with the Magic Remote), themeable UI, and resilient playback handling for webOS constraints.
 
 The app was inspired by other great apps and themes, like JellySee, AndroidTV-FireTV, Moonfin, ElegantFin and more. Check them out.
 
@@ -28,8 +28,8 @@ In case of an issue, please report it on GitHub in as much detail as possible.
 - Elegant (default) and Classic navigation themes
 - Performance Mode and Performance+ Mode (animation reduction options)
 - Rich Media Details workflows (favorites, watched status, track pickers, episodes/seasons, side list toggle)
-- Player with direct play, direct stream, and transcode handling
-- Subtitle/audio compatibility fallbacks for webOS playback paths
+- Player with dynamic-range-aware direct play/direct stream/transcode fallback paths (DV -> HDR -> SDR)
+- Subtitle/audio compatibility fallbacks for webOS playback paths, with optional subtitle burn-in policy
 - Diagnostics tools (logs, performance overlay, cache wipe, style debug panel)
 - Modular Jellyfin service architecture (session/library/item-state/playback domain split)
 
@@ -133,6 +133,10 @@ localStorage.setItem('breezyfinFocusDebug', '1');
 Diagnostics currently include:
 
 - Performance Overlay (`FPS`, `Input`, `Mode`)
+- Playback toast with active dynamic range / play method (for quick validation)
+- Unified toast styling/behavior across Player, Media Details, and Settings feedback
+- Device playback capability summary in Settings (DV/HDR/codec/audio support snapshot + probe source/timestamp)
+- Configurable capability probe refresh period (default 30 days) plus manual "Refresh now" action
 - Relaxed Playback Profile toggle (debug-only visibility)
 - Styling Debug Panel shortcut (debug-only visibility)
 - Logs viewer and clear action

--- a/README.md
+++ b/README.md
@@ -24,14 +24,12 @@ In case of an issue, please report it on GitHub in as much detail as possible.
 
 - Multi-server, multi-user saved sessions with quick account switching
 - Session restore on startup, with automatic redirect to Login when token/session is expired
-- Home, Library, Search, Favorites, Media Details, and Player panels
+- TV-first navigation tuned for LG Magic Remote (5-way and pointer flows)
 - Elegant (default) and Classic navigation themes
 - Performance Mode and Performance+ Mode (animation reduction options)
-- Rich Media Details workflows (favorites, watched status, track pickers, episodes/seasons, side list toggle)
 - Player with dynamic-range-aware direct play/direct stream/transcode fallback paths (DV -> HDR -> SDR)
 - Subtitle/audio compatibility fallbacks for webOS playback paths, with optional subtitle burn-in policy
-- Diagnostics tools (logs, performance overlay, cache wipe, style debug panel)
-- Modular Jellyfin service architecture (session/library/item-state/playback domain split)
+- Built-in runtime diagnostics for playback validation and troubleshooting
 
 ## Install on TV (IPK)
 
@@ -134,7 +132,6 @@ Diagnostics currently include:
 
 - Performance Overlay (`FPS`, `Input`, `Mode`)
 - Playback toast with active dynamic range / play method (for quick validation)
-- Unified toast styling/behavior across Player, Media Details, and Settings feedback
 - Device playback capability summary in Settings (DV/HDR/codec/audio support snapshot + probe source/timestamp)
 - Configurable capability probe refresh period (default 30 days) plus manual "Refresh now" action
 - Relaxed Playback Profile toggle (debug-only visibility)

--- a/THEMES.md
+++ b/THEMES.md
@@ -6,18 +6,18 @@ This file documents how theming works in Breezyfin, which files own each part, a
 
 Breezyfin uses a layered theme model:
 
-1. Global tokens and behavior in `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/global.css`.
+1. Global tokens and behavior in `src/global.css`.
 2. Theme token packs in:
-   - `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/themes/classic.css`
-   - `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/themes/elegant.css`
+   - `src/styles/themes/classic.css`
+   - `src/styles/themes/elegant.css`
 3. Panel/component local styles in module LESS files and split subfiles.
 4. Runtime capability + mode attributes set by the app root.
 
-All theme files are loaded from `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/index.js`.
+All theme files are loaded from `src/index.js`.
 
 ## 2) Runtime attributes
 
-The app sets the theme/mode/platform attributes in `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/App/App.js`.
+The app sets the theme/mode/platform attributes in `src/App/App.js`.
 
 These attributes are what CSS listens to:
 
@@ -34,20 +34,20 @@ These attributes are what CSS listens to:
 - `data-bf-aspect-ratio`: `on` or `off`
 - `data-bf-backdrop-filter`: `on` or `off`
 
-Version/capability detection is implemented in `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/utils/platformCapabilities.js`.
+Version/capability detection is implemented in `src/utils/platformCapabilities.js`.
 
 ## 3) Core theme files
 
 ### Token files
 
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/themes/classic.css`
+- `src/styles/themes/classic.css`
   - Defines Classic tokens and classic baseline surfaces.
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/themes/elegant.css`
+- `src/styles/themes/elegant.css`
   - Defines Elegant tokens and elegant-specific typography/chrome overrides.
 
 ### Global behavior
 
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/global.css`
+- `src/global.css`
   - Shared layout tokens (`--bf-header-height`, `--bf-toolbar-height`, panel offsets).
   - Sandstone chrome normalization.
   - Performance mode and Performance+ global behavior.
@@ -55,17 +55,17 @@ Version/capability detection is implemented in `/Users/patrikas/Desktop/IT/Devel
 
 ### Shared style primitives
 
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/cardStyles.less`
+- `src/styles/cardStyles.less`
   - Reusable card shells, focus effects, image shells, and shared status badge primitives (default/count, watched, favorite).
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/popupStyles.module.less`
+- `src/styles/popupStyles.module.less`
   - Shared popup surface skin with Classic/Elegant token usage.
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/popupStyles.js`
+- `src/styles/popupStyles.js`
   - JS export for popup style class wiring.
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/popup-styles/_popup-styles-compat-webos6.less`
+- `src/styles/popup-styles/_popup-styles-compat-webos6.less`
   - webOS 6 popup fallback behaviors (solid-surface compatibility path).
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/panelLayoutMixins.less`
+- `src/styles/panelLayoutMixins.less`
   - Shared panel fill container mixin.
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/compatMixins.less`
+- `src/styles/compatMixins.less`
   - Shared compatibility mixins (gap fallbacks, scroll metric stabilization).
 
 ## 4) Panel styles split pattern
@@ -79,20 +79,20 @@ Most panels use split files under `*-panel-styles/`:
 
 Examples:
 
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/MediaDetailsPanel.module.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/SearchPanel.module.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/LibraryPanel.module.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/FavoritesPanel.module.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/LoginPanel.module.less`
+- `src/views/MediaDetailsPanel.module.less`
+- `src/views/SearchPanel.module.less`
+- `src/views/LibraryPanel.module.less`
+- `src/views/FavoritesPanel.module.less`
+- `src/views/LoginPanel.module.less`
 
 ### Component-level split/compat examples
 
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/components/Toolbar.module.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/components/toolbar-styles/_toolbar-compat-webos6.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/components/HeroBanner.module.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/components/hero-banner-styles/_hero-banner-compat-webos6.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/components/MediaRow.module.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/components/media-row-styles/_media-row-compat-webos6.less`
+- `src/components/Toolbar.module.less`
+- `src/components/toolbar-styles/_toolbar-compat-webos6.less`
+- `src/components/HeroBanner.module.less`
+- `src/components/hero-banner-styles/_hero-banner-compat-webos6.less`
+- `src/components/MediaRow.module.less`
+- `src/components/media-row-styles/_media-row-compat-webos6.less`
 
 ## 5) Theme features by mode
 
@@ -135,12 +135,12 @@ Compatibility is capability-driven and scoped by root attributes.
 
 Key files:
 
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/components/toolbar-styles/_toolbar-compat-webos6.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/media-details-styles/_media-details-compat-webos6.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/login-panel-styles/_login-panel-compat-webos6.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/components/media-row-styles/_media-row-compat-webos6.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/components/hero-banner-styles/_hero-banner-compat-webos6.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/styles/popup-styles/_popup-styles-compat-webos6.less`
+- `src/components/toolbar-styles/_toolbar-compat-webos6.less`
+- `src/views/media-details-styles/_media-details-compat-webos6.less`
+- `src/views/login-panel-styles/_login-panel-compat-webos6.less`
+- `src/components/media-row-styles/_media-row-compat-webos6.less`
+- `src/components/hero-banner-styles/_hero-banner-compat-webos6.less`
+- `src/styles/popup-styles/_popup-styles-compat-webos6.less`
 
 ### webOS 22 compatibility
 
@@ -148,13 +148,13 @@ Key files:
 
 Key files:
 
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/search-panel-styles/_search-panel-compat-webos22.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/favorites-panel-styles/_favorites-panel-compat-webos22.less`
-- `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/library-panel-styles/_library-panel-compat-webos22.less`
+- `src/views/search-panel-styles/_search-panel-compat-webos22.less`
+- `src/views/favorites-panel-styles/_favorites-panel-compat-webos22.less`
+- `src/views/library-panel-styles/_library-panel-compat-webos22.less`
 
 ## 7) Settings storage
 
-Theme-related settings are managed from `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/views/SettingsPanel.js` and persisted via `/Users/patrikas/Desktop/IT/Development/Breezyfin/src/utils/settingsStorage.js`.
+Theme-related settings are managed from `src/views/SettingsPanel.js` and persisted via `src/utils/settingsStorage.js`.
 
 Relevant settings:
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -21,7 +21,6 @@ This is the current backlog for v0.1.5 release. Should be updated with further r
   - `src/services/jellyfin/sessionApi.js`
 - Identify the cause for FPS drops in Media Details panel when scrolling. Loading delay in panels might be directly related to the FPS drops since they are not present in Simulator tests. This might cause issues for TVs that were released in 2022 or prior. It could be related to backdrop/cast/episode image quality or complexity as not all media causes this behavior. Performance Mode should be improved in episode list to reduce heavyweight styling.
 - Could consider using WEBP for images to increase performance. 
-- In PlayerPanel, the title next to the back button should include the SxEx numbers.
 
 ## Medium priority
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -19,6 +19,9 @@ This is the current backlog for v0.1.5 release. Should be updated with further r
   - `src/services/jellyfin/playbackApi.js`
   - `src/services/jellyfin/libraryApi.js`
   - `src/services/jellyfin/sessionApi.js`
+- Identify the cause for FPS drops in Media Details panel when scrolling. Loading delay in panels might be directly related to the FPS drops since they are not present in Simulator tests. This might cause issues for TVs that were released in 2022 or prior. It could be related to backdrop/cast/episode image quality or complexity as not all media causes this behavior. Performance Mode should be improved in episode list to reduce heavyweight styling.
+- Could consider using WEBP for images to increase performance. 
+- In PlayerPanel, the title next to the back button should include the SxEx numbers.
 
 ## Medium priority
 
@@ -45,6 +48,7 @@ This is the current backlog for v0.1.5 release. Should be updated with further r
 - Inspect button styling in Favorites panel to ensure we're using already existing mixins. Alter Mark Watched button hover background color to match the icon color (already done for Favorite button) via shared styles or mixins and ensure that is also used in episode list and favorite panels. 
 - Fix badge spacing and sizing on webOS 6. We also need to make sure badges actually appear in Favorites and Search panel on webOS 6.
 - Inspect the cause for the first library option having extra whitespace separating it from the second option in webOS 6. 
+- Apply our PlayerPanel loading animation to all panels that would replace the default loading animation.
 
 ## Maintenance checks (recurring)
 

--- a/VIEWS.md
+++ b/VIEWS.md
@@ -21,15 +21,6 @@ This guide covers top-level panels and panel-local modules in `src/views/`.
 - `src/views/media-details-panel/`
 - `src/views/settings-panel/` (`components/`, `constants.js`, `labels.js`)
 
-Player panel notable behaviors:
-- Episode header title uses `SxEx: {Title}` formatting when season/episode numbers are available.
-- Leaving Player returns to the currently playing episode details item, even after next-episode transitions.
-
-Settings panel notable sections:
-- Runtime device playback capability summary (DV/HDR/audio/video support snapshot)
-- Capability probe refresh controls (refresh period + manual refresh)
-- Shared toast feedback for capability refresh actions
-
 ## Conventions
 
 - Prefer shared hooks from `src/hooks/` before adding panel-local hooks.

--- a/VIEWS.md
+++ b/VIEWS.md
@@ -21,6 +21,10 @@ This guide covers top-level panels and panel-local modules in `src/views/`.
 - `src/views/media-details-panel/`
 - `src/views/settings-panel/` (`components/`, `constants.js`, `labels.js`)
 
+Player panel notable behaviors:
+- Episode header title uses `SxEx: {Title}` formatting when season/episode numbers are available.
+- Leaving Player returns to the currently playing episode details item, even after next-episode transitions.
+
 Settings panel notable sections:
 - Runtime device playback capability summary (DV/HDR/audio/video support snapshot)
 - Capability probe refresh controls (refresh period + manual refresh)

--- a/VIEWS.md
+++ b/VIEWS.md
@@ -21,6 +21,11 @@ This guide covers top-level panels and panel-local modules in `src/views/`.
 - `src/views/media-details-panel/`
 - `src/views/settings-panel/` (`components/`, `constants.js`, `labels.js`)
 
+Settings panel notable sections:
+- Runtime device playback capability summary (DV/HDR/audio/video support snapshot)
+- Capability probe refresh controls (refresh period + manual refresh)
+- Shared toast feedback for capability refresh actions
+
 ## Conventions
 
 - Prefer shared hooks from `src/hooks/` before adding panel-local hooks.

--- a/appinfo.json
+++ b/appinfo.json
@@ -1,6 +1,6 @@
 {
     "id": "com.breezyfin.app",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "vendor": "botagas",
     "type": "web",
     "main": "index.html",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "breezyfin",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "breezyfin",
-			"version": "0.1.5",
+			"version": "0.1.6",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@enact/core": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "breezyfin",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "Jellyfin client for LG webOS TVs, built with Enact Sandstone.",
 	"author": "",
 	"main": "src/index.js",

--- a/src/App/hooks/usePanelHistory.js
+++ b/src/App/hooks/usePanelHistory.js
@@ -82,11 +82,23 @@ export const usePanelHistory = ({
 		return null;
 	}, []);
 
+	const updateLatestHistorySnapshot = useCallback((updater) => {
+		if (typeof updater !== 'function') return false;
+		const history = panelHistoryRef.current;
+		if (!history.length) return false;
+		const currentSnapshot = history[history.length - 1];
+		const nextSnapshot = updater(currentSnapshot);
+		if (!nextSnapshot || nextSnapshot === currentSnapshot) return false;
+		panelHistoryRef.current = [...history.slice(0, -1), nextSnapshot];
+		return true;
+	}, []);
+
 	return {
 		pushPanelHistory,
 		clearPanelHistory,
 		navigateBackInHistory,
-		getHistoryFallbackItem
+		getHistoryFallbackItem,
+		updateLatestHistorySnapshot
 	};
 };
 

--- a/src/components/BreezyToast.js
+++ b/src/components/BreezyToast.js
@@ -1,0 +1,17 @@
+import css from './BreezyToast.module.less';
+
+const BreezyToast = ({message, visible}) => {
+	if (!message) return null;
+
+	return (
+		<div
+			className={`${css.toast} ${visible ? css.toastVisible : ''}`}
+			role="status"
+			aria-live="polite"
+		>
+			{message}
+		</div>
+	);
+};
+
+export default BreezyToast;

--- a/src/components/BreezyToast.module.less
+++ b/src/components/BreezyToast.module.less
@@ -1,0 +1,31 @@
+.toast {
+	position: fixed;
+	top: 1.25rem;
+	left: 50%;
+	transform: translate(-50%, -0.65rem);
+	opacity: 0;
+	padding: 0.72rem 1.35rem;
+	max-width: calc(100vw - 2.5rem);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	background: var(--bf-theme-message-bg, rgba(18, 24, 36, 0.86));
+	border: 1px solid var(--bf-theme-message-border, rgba(255, 255, 255, 0.22));
+	border-radius: 0.8rem;
+	color: var(--bf-theme-message-color, rgba(245, 250, 255, 0.96));
+	font-size: 0.88em;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+	line-height: 1.2;
+	backdrop-filter: blur(12px);
+	-webkit-backdrop-filter: blur(12px);
+	box-shadow: var(--bf-theme-message-shadow, 0 0.5rem 1.4rem rgba(0, 0, 0, 0.4));
+	pointer-events: none;
+	z-index: 180;
+	transition: opacity 220ms ease, transform 220ms ease;
+}
+
+.toastVisible {
+	opacity: 1;
+	transform: translate(-50%, 0);
+}

--- a/src/hooks/useDisclosureHandlers.js
+++ b/src/hooks/useDisclosureHandlers.js
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
 
-// Builds stable open/close handlers keyed by disclosure id to avoid panel-level callback boilerplate.
 export const useDisclosureHandlers = (keys, openDisclosure, closeDisclosure) => {
 	return useMemo(() => {
 		const handlers = {};

--- a/src/services/jellyfin/playbackProfileBuilder.js
+++ b/src/services/jellyfin/playbackProfileBuilder.js
@@ -1,4 +1,75 @@
-export const buildPlaybackInfoBasePayload = (options = {}, {relaxedPlaybackProfile = false} = {}) => {
+import {getRuntimePlatformCapabilities} from '../../utils/platformCapabilities';
+import {normalizeDynamicRangeCap} from '../../utils/playbackDynamicRange';
+
+const VIDEO_RANGE_TYPES = {
+	DV_FALLBACKS: [
+		'DOVIWithHDR10',
+		'DOVIWithHDR10Plus',
+		'DOVIWithHLG',
+		'DOVIWithSDR',
+		'DOVIWithEL',
+		'DOVIWithELHDR10Plus',
+		'DOVIInvalid'
+	],
+	DV_HDR_ONLY_FALLBACKS: [
+		'DOVIWithHDR10',
+		'DOVIWithHDR10Plus',
+		'DOVIWithHLG',
+		'DOVIWithSDR'
+	]
+};
+
+const addUnique = (target, values) => {
+	values.forEach((value) => {
+		if (!target.includes(value)) {
+			target.push(value);
+		}
+	});
+};
+
+const getPlaybackCapabilities = () => {
+	const runtimeCapabilities = getRuntimePlatformCapabilities();
+	return runtimeCapabilities?.playback || {};
+};
+
+const getContainerAudioCodecs = (playbackCapabilities, container) => {
+	const map = playbackCapabilities.audioCodecsByContainer || {};
+	const codecs = map[container] || playbackCapabilities.audioCodecs || ['aac', 'mp3', 'ac3', 'eac3'];
+	return Array.from(new Set(codecs.map((codec) => codec.toLowerCase())));
+};
+
+export const buildVideoRangeTypeValue = (playbackCapabilities, dynamicRangeCap = 'auto') => {
+	const cap = normalizeDynamicRangeCap(dynamicRangeCap);
+	const rangeTypes = ['SDR'];
+	const supportsHdr10 = playbackCapabilities.supportsHdr10 !== false;
+	const supportsHlg = playbackCapabilities.supportsHlg !== false;
+	const supportsDolbyVision = playbackCapabilities.supportsDolbyVision === true;
+
+	if (supportsHdr10) {
+		addUnique(rangeTypes, ['HDR10', 'HDR10Plus']);
+	}
+	if (supportsHlg) {
+		addUnique(rangeTypes, ['HLG']);
+	}
+
+	if (cap === 'auto') {
+		if (supportsDolbyVision) {
+			addUnique(rangeTypes, ['DOVI']);
+		}
+		addUnique(rangeTypes, VIDEO_RANGE_TYPES.DV_FALLBACKS);
+	} else if (cap === 'hdr10') {
+		addUnique(rangeTypes, VIDEO_RANGE_TYPES.DV_HDR_ONLY_FALLBACKS);
+	} else if (cap === 'sdr') {
+		addUnique(rangeTypes, ['DOVIWithSDR']);
+	}
+
+	return rangeTypes.join('|');
+};
+
+export const buildPlaybackInfoBasePayload = (
+	options = {},
+	{relaxedPlaybackProfile = false, forceSubtitleBurnIn = false} = {}
+) => {
 	const payload = {};
 	if (options.mediaSourceId) {
 		payload.MediaSourceId = options.mediaSourceId;
@@ -8,9 +79,7 @@ export const buildPlaybackInfoBasePayload = (options = {}, {relaxedPlaybackProfi
 	}
 	if (options.subtitleStreamIndex !== undefined && options.subtitleStreamIndex !== null) {
 		payload.SubtitleStreamIndex = options.subtitleStreamIndex;
-		// In strict/default mode prefer burned-in subtitles for webOS compatibility.
-		// Relaxed profile lets Jellyfin choose alternate subtitle handling paths.
-		if (!relaxedPlaybackProfile && options.subtitleStreamIndex >= 0) {
+		if (!relaxedPlaybackProfile && forceSubtitleBurnIn && options.subtitleStreamIndex >= 0) {
 			payload.SubtitleMethod = 'Encode';
 		}
 	}
@@ -20,125 +89,169 @@ export const buildPlaybackInfoBasePayload = (options = {}, {relaxedPlaybackProfi
 	return payload;
 };
 
-export const buildDirectPlayProfiles = (forceTranscoding, relaxedPlaybackProfile) => {
+export const buildDirectPlayProfiles = (forceTranscoding, relaxedPlaybackProfile, playbackCapabilities) => {
 	if (forceTranscoding) return [];
+
+	const supportsHevc = playbackCapabilities.supportsHevc !== false;
+	const supportsAv1 = playbackCapabilities.supportsAv1 === true;
+	const supportsVp9 = playbackCapabilities.supportsVp9 === true;
+	const webosVersion = Number.isFinite(playbackCapabilities.webosVersion) ? playbackCapabilities.webosVersion : 0;
+	const supportsMkv = webosVersion >= 4 || playbackCapabilities.webosVersion == null;
+	const supportsWebm = webosVersion >= 5;
+
+	const mp4VideoCodecs = ['h264'];
+	if (supportsHevc) mp4VideoCodecs.push('hevc');
+	if (supportsAv1) mp4VideoCodecs.push('av1');
+
+	const mkvVideoCodecs = ['h264', 'mpeg4', 'mpeg2video'];
+	if (supportsHevc) mkvVideoCodecs.push('hevc');
+	if (supportsVp9) mkvVideoCodecs.push('vp9');
+	if (supportsAv1) mkvVideoCodecs.push('av1');
+
+	const mp4AudioCodecs = getContainerAudioCodecs(playbackCapabilities, 'mp4');
+	const mkvAudioCodecs = getContainerAudioCodecs(playbackCapabilities, 'mkv');
+	const tsAudioCodecs = getContainerAudioCodecs(playbackCapabilities, 'ts');
+	const hlsAudioCodecs = getContainerAudioCodecs(playbackCapabilities, 'hls');
+
 	const directPlayProfiles = [
-		// webOS natively supports HLS
-		{Container: 'hls', Type: 'Video', VideoCodec: 'h264,hevc', AudioCodec: 'aac,ac3,eac3,mp3'},
-		// MP4 container - webOS TVs have excellent MP4 support
-		{Container: 'mp4,m4v', Type: 'Video', VideoCodec: 'h264,hevc,mpeg4,mpeg2video', AudioCodec: 'aac,ac3,eac3,mp3,mp2'},
-		// MKV support varies by webOS version, but newer versions support it
-		// Drop DTS from the direct-play list so Jellyfin will transcode DTS/DTS-HD
-		{Container: 'mkv', Type: 'Video', VideoCodec: 'h264,hevc,mpeg4,mpeg2video', AudioCodec: 'aac,ac3,eac3,mp3,mp2'},
-		// Audio direct play
+		{
+			Container: 'hls',
+			Type: 'Video',
+			VideoCodec: mp4VideoCodecs.join(','),
+			AudioCodec: hlsAudioCodecs.join(',')
+		},
+		{
+			Container: 'mp4,m4v,mov',
+			Type: 'Video',
+			VideoCodec: mp4VideoCodecs.join(','),
+			AudioCodec: mp4AudioCodecs.join(',')
+		},
+		{
+			Container: 'ts,mpegts,m2ts',
+			Type: 'Video',
+			VideoCodec: mp4VideoCodecs.join(','),
+			AudioCodec: tsAudioCodecs.join(',')
+		},
 		{Container: 'mp3', Type: 'Audio', AudioCodec: 'mp3'},
 		{Container: 'aac', Type: 'Audio', AudioCodec: 'aac'},
-		{Container: 'flac', Type: 'Audio', AudioCodec: 'flac'},
-		{Container: 'webm', Type: 'Audio', AudioCodec: 'vorbis,opus'}
+		{Container: 'flac', Type: 'Audio', AudioCodec: 'flac'}
 	];
-	if (relaxedPlaybackProfile) {
+
+	if (supportsMkv) {
 		directPlayProfiles.push({
 			Container: 'mkv',
 			Type: 'Video',
-			VideoCodec: 'h264,hevc,mpeg4,mpeg2video,vp9,av1',
-			AudioCodec: 'aac,ac3,eac3,mp3,mp2,flac,opus,vorbis,pcm,dts,dca,truehd'
+			VideoCodec: mkvVideoCodecs.join(','),
+			AudioCodec: mkvAudioCodecs.join(',')
 		});
 	}
+
+	if (supportsWebm && relaxedPlaybackProfile) {
+		directPlayProfiles.push({
+			Container: 'webm',
+			Type: 'Video',
+			VideoCodec: ['vp8', supportsVp9 ? 'vp9' : null, supportsAv1 ? 'av1' : null].filter(Boolean).join(','),
+			AudioCodec: 'vorbis,opus'
+		});
+		directPlayProfiles.push({Container: 'webm', Type: 'Audio', AudioCodec: 'vorbis,opus'});
+	}
+
 	return directPlayProfiles;
 };
 
-export const buildTranscodingProfiles = (relaxedPlaybackProfile) => {
+export const buildTranscodingProfiles = (relaxedPlaybackProfile, playbackCapabilities) => {
+	const maxAudioChannels = String(playbackCapabilities.maxAudioChannels || 6);
+	const supportsHevc = playbackCapabilities.supportsHevc !== false;
+	const hlsContainer = playbackCapabilities.nativeHlsFmp4 ? 'mp4' : 'ts';
+	const hlsAudioCodecs = Array.from(
+		new Set(
+			getContainerAudioCodecs(playbackCapabilities, 'hls').filter((codec) => ['aac', 'ac3', 'eac3', 'mp3'].includes(codec))
+		)
+	);
+	if (!hlsAudioCodecs.length) {
+		hlsAudioCodecs.push('aac');
+	}
+
 	const transcodingProfiles = [
-		// HLS transcoding - BEST for webOS (hardware accelerated)
-		// Use stereo for maximum compatibility
-		{
-			Container: 'ts',
+		...(supportsHevc ? [{
+			Container: hlsContainer,
 			Type: 'Video',
-			AudioCodec: 'aac',
+			AudioCodec: hlsAudioCodecs.join(','),
+			VideoCodec: 'hevc',
+			Context: 'Streaming',
+			Protocol: 'hls',
+			MaxAudioChannels: maxAudioChannels,
+			MinSegments: '1',
+			BreakOnNonKeyFrames: false
+		}] : []),
+		{
+			Container: hlsContainer,
+			Type: 'Video',
+			AudioCodec: hlsAudioCodecs.join(','),
 			VideoCodec: 'h264',
 			Context: 'Streaming',
 			Protocol: 'hls',
-			MaxAudioChannels: '2',
+			MaxAudioChannels: maxAudioChannels,
 			MinSegments: '1',
 			BreakOnNonKeyFrames: false
 		},
-		// HLS Audio
 		{
-			Container: 'ts',
+			Container: 'mp4',
+			Type: 'Video',
+			AudioCodec: 'aac,ac3,eac3',
+			VideoCodec: 'h264',
+			Context: 'Static',
+			MaxAudioChannels: maxAudioChannels
+		},
+		{
+			Container: 'mp3',
+			Type: 'Audio',
+			AudioCodec: 'mp3',
+			Context: 'Streaming',
+			Protocol: 'http'
+		},
+		{
+			Container: 'aac',
 			Type: 'Audio',
 			AudioCodec: 'aac',
 			Context: 'Streaming',
-			Protocol: 'hls',
-			MaxAudioChannels: '2',
-			BreakOnNonKeyFrames: false
-		},
-		// HTTP Audio fallback
-		{Container: 'mp3', Type: 'Audio', AudioCodec: 'mp3', Context: 'Streaming', Protocol: 'http', MaxAudioChannels: '2'}
+			Protocol: 'http'
+		}
 	];
 
-	if (relaxedPlaybackProfile) {
-		transcodingProfiles.push(
-			{
-				Container: 'ts',
-				Type: 'Video',
-				AudioCodec: 'aac,ac3,mp3',
-				VideoCodec: 'h264',
-				Context: 'Streaming',
-				Protocol: 'hls',
-				MaxAudioChannels: '6',
-				MinSegments: '1',
-				BreakOnNonKeyFrames: false
-			},
-			{
-				Container: 'mp4',
-				Type: 'Video',
-				AudioCodec: 'aac,ac3,mp3',
-				VideoCodec: 'h264',
-				Context: 'Streaming',
-				Protocol: 'http',
-				MaxAudioChannels: '6'
-			}
-		);
+	if (relaxedPlaybackProfile && supportsHevc) {
+		transcodingProfiles.push({
+			Container: 'mp4',
+			Type: 'Video',
+			AudioCodec: 'aac,ac3,eac3',
+			VideoCodec: 'hevc',
+			Context: 'Streaming',
+			Protocol: 'http',
+			MaxAudioChannels: maxAudioChannels
+		});
 	}
 
 	return transcodingProfiles;
 };
 
-export const buildSubtitleProfiles = (relaxedPlaybackProfile) => {
-	if (relaxedPlaybackProfile) {
-		return [
-			{Format: 'ass', Method: 'External'},
-			{Format: 'ssa', Method: 'External'},
-			{Format: 'srt', Method: 'External'},
-			{Format: 'subrip', Method: 'External'},
-			{Format: 'vtt', Method: 'External'},
-			{Format: 'webvtt', Method: 'External'},
-			{Format: 'ass', Method: 'Encode'},
-			{Format: 'ssa', Method: 'Encode'},
-			{Format: 'srt', Method: 'Encode'},
-			{Format: 'subrip', Method: 'Encode'},
-			{Format: 'vtt', Method: 'Encode'},
-			{Format: 'webvtt', Method: 'Encode'},
-			{Format: 'pgs', Method: 'Encode'},
-			{Format: 'pgssub', Method: 'Encode'},
-			{Format: 'dvbsub', Method: 'Encode'},
-			{Format: 'dvdsub', Method: 'Encode'}
-		];
+export const buildSubtitleProfiles = ({relaxedPlaybackProfile, forceSubtitleBurnIn}) => {
+	const textFormats = ['srt', 'subrip', 'vtt', 'webvtt', 'ass', 'ssa', 'smi', 'sami', 'ttml', 'dfxp'];
+	const imageFormats = ['pgs', 'pgssub', 'dvbsub', 'dvdsub'];
+
+	if (forceSubtitleBurnIn) {
+		return [...textFormats, ...imageFormats].map((format) => ({Format: format, Method: 'Encode'}));
 	}
-	// Burn-in all subtitles for webOS compatibility.
-	// webOS has limited native subtitle support, so we transcode with burn-in.
-	return [
-		{Format: 'ass', Method: 'Encode'},
-		{Format: 'ssa', Method: 'Encode'},
-		{Format: 'srt', Method: 'Encode'},
-		{Format: 'subrip', Method: 'Encode'},
-		{Format: 'vtt', Method: 'Encode'},
-		{Format: 'webvtt', Method: 'Encode'},
-		{Format: 'pgs', Method: 'Encode'},
-		{Format: 'pgssub', Method: 'Encode'},
-		{Format: 'dvbsub', Method: 'Encode'},
-		{Format: 'dvdsub', Method: 'Encode'}
-	];
+
+	const profiles = textFormats.map((format) => ({Format: format, Method: 'External'}));
+	if (relaxedPlaybackProfile) {
+		textFormats.forEach((format) => {
+			profiles.push({Format: format, Method: 'Encode'});
+		});
+	}
+	imageFormats.forEach((format) => {
+		profiles.push({Format: format, Method: 'Encode'});
+	});
+	return profiles;
 };
 
 export const buildPlaybackDeviceProfile = ({
@@ -146,75 +259,108 @@ export const buildPlaybackDeviceProfile = ({
 	maxBitrateSetting,
 	directPlayProfiles,
 	transcodingProfiles,
-	subtitleProfiles
+	subtitleProfiles,
+	playbackCapabilities,
+	dynamicRangeCap
 }) => {
+	const maxStreamingBitrate = maxBitrateSetting
+		? maxBitrateSetting * 1000000
+		: (playbackCapabilities.maxStreamingBitrate || 120000000);
+	const maxAudioChannels = String(playbackCapabilities.maxAudioChannels || 6);
+	const videoRangeTypes = buildVideoRangeTypeValue(playbackCapabilities, dynamicRangeCap);
+
+	const codecProfiles = [
+		{
+			Type: 'Video',
+			Codec: 'h264',
+			Conditions: [
+				{Condition: 'EqualsAny', Property: 'VideoProfile', Value: 'high|main|baseline|constrained baseline', IsRequired: false},
+				{Condition: 'LessThanEqual', Property: 'VideoLevel', Value: '51', IsRequired: false},
+				{Condition: 'EqualsAny', Property: 'VideoRangeType', Value: 'SDR|HDR10|HDR10Plus|HLG', IsRequired: false},
+				{Condition: 'NotEquals', Property: 'IsAnamorphic', Value: 'true', IsRequired: false}
+			]
+		},
+		{
+			Type: 'Video',
+			Codec: 'hevc',
+			Conditions: [
+				{Condition: 'EqualsAny', Property: 'VideoProfile', Value: 'main|main 10', IsRequired: false},
+				{Condition: 'LessThanEqual', Property: 'VideoLevel', Value: '186', IsRequired: false},
+				{Condition: 'EqualsAny', Property: 'VideoRangeType', Value: videoRangeTypes, IsRequired: false},
+				{Condition: 'NotEquals', Property: 'IsAnamorphic', Value: 'true', IsRequired: false}
+			]
+		},
+		{
+			Type: 'Video',
+			Codec: 'vp9',
+			Conditions: [
+				{Condition: 'EqualsAny', Property: 'VideoRangeType', Value: videoRangeTypes, IsRequired: false}
+			]
+		},
+		{
+			Type: 'Video',
+			Codec: 'av1',
+			Conditions: [
+				{Condition: 'EqualsAny', Property: 'VideoProfile', Value: 'main', IsRequired: false},
+				{Condition: 'LessThanEqual', Property: 'VideoLevel', Value: '15', IsRequired: false},
+				{Condition: 'EqualsAny', Property: 'VideoRangeType', Value: videoRangeTypes, IsRequired: false}
+			]
+		},
+		{
+			Type: 'VideoAudio',
+			Codec: 'aac,mp3,ac3,eac3',
+			Conditions: [
+				{Condition: 'LessThanEqual', Property: 'AudioChannels', Value: maxAudioChannels, IsRequired: false}
+			]
+		}
+	];
+
+	const responseProfiles = [
+		{
+			Type: 'Video',
+			Container: 'm4v',
+			MimeType: 'video/mp4'
+		},
+		{
+			Type: 'Video',
+			Container: 'mkv',
+			MimeType: 'video/x-matroska'
+		}
+	];
+
 	return {
 		Name: relaxedPlaybackProfile ? 'Breezyfin webOS TV (Relaxed)' : 'Breezyfin webOS TV',
-		MaxStreamingBitrate: maxBitrateSetting ? maxBitrateSetting * 1000000 : 120000000,
-		MaxStaticBitrate: 100000000,
+		MaxStreamingBitrate: maxStreamingBitrate,
+		MaxStaticBitrate: maxStreamingBitrate,
 		MusicStreamingTranscodingBitrate: 384000,
 		DirectPlayProfiles: directPlayProfiles,
 		TranscodingProfiles: transcodingProfiles,
 		SubtitleProfiles: subtitleProfiles,
 		ContainerProfiles: [],
-		CodecProfiles: [
-			{
-				Type: 'Video',
-				Codec: 'h264',
-				Conditions: [
-					{Condition: 'EqualsAny', Property: 'VideoProfile', Value: 'high|main|baseline|constrained baseline'},
-					{Condition: 'LessThanEqual', Property: 'VideoLevel', Value: '51'},
-					{Condition: 'NotEquals', Property: 'IsAnamorphic', Value: 'true', IsRequired: false}
-				]
-			},
-			{
-				Type: 'Video',
-				Codec: 'hevc',
-				Conditions: [
-					{Condition: 'EqualsAny', Property: 'VideoProfile', Value: 'main'},
-					{Condition: 'LessThanEqual', Property: 'VideoLevel', Value: '120'},
-					{Condition: 'NotEquals', Property: 'IsAnamorphic', Value: 'true', IsRequired: false}
-				]
-			},
-			{
-				Type: 'VideoAudio',
-				Codec: 'aac,mp3',
-				Conditions: [
-					{Condition: 'LessThanEqual', Property: 'AudioChannels', Value: '6'}
-				]
-			},
-			{
-				Type: 'VideoAudio',
-				Codec: 'ac3,eac3',
-				Conditions: [
-					{Condition: 'LessThanEqual', Property: 'AudioChannels', Value: '6'}
-				]
-			}
-		],
-		ResponseProfiles: [
-			{
-				Type: 'Video',
-				Container: 'm4v',
-				MimeType: 'video/mp4'
-			}
-		]
+		CodecProfiles: codecProfiles,
+		ResponseProfiles: responseProfiles
 	};
 };
 
 export const buildPlaybackRequestContext = (options = {}) => {
+	const playbackCapabilities = getPlaybackCapabilities();
 	const relaxedPlaybackProfile = options.relaxedPlaybackProfile === true;
 	const forceTranscoding = options.forceTranscoding === true;
-	const enableTranscoding = options.enableTranscoding !== false; // default on
+	const enableTranscoding = options.enableTranscoding !== false;
+	const forceSubtitleBurnIn = options.forceSubtitleBurnIn === true;
+	const dynamicRangeCap = normalizeDynamicRangeCap(options.dynamicRangeCap);
 	// Keep stream copy available on transcode sessions unless explicitly disabled.
-	// This mirrors Jellyfin client behavior and prevents fragile full re-encode failures.
 	const allowStreamCopyOnTranscode = options.allowStreamCopyOnTranscode !== false;
 	const allowStreamCopy = enableTranscoding && (!forceTranscoding || allowStreamCopyOnTranscode);
 	const maxBitrateSetting = options.maxBitrate ? parseInt(options.maxBitrate, 10) : null;
 	const requestedAudioStreamIndex = Number.isInteger(options.audioStreamIndex) ? options.audioStreamIndex : null;
-	const payload = buildPlaybackInfoBasePayload(options, {relaxedPlaybackProfile});
-	const directPlayProfiles = buildDirectPlayProfiles(forceTranscoding, relaxedPlaybackProfile);
-	const transcodingProfiles = buildTranscodingProfiles(relaxedPlaybackProfile);
-	const subtitleProfiles = buildSubtitleProfiles(relaxedPlaybackProfile);
+	const payload = buildPlaybackInfoBasePayload(options, {
+		relaxedPlaybackProfile,
+		forceSubtitleBurnIn
+	});
+	const directPlayProfiles = buildDirectPlayProfiles(forceTranscoding, relaxedPlaybackProfile, playbackCapabilities);
+	const transcodingProfiles = buildTranscodingProfiles(relaxedPlaybackProfile, playbackCapabilities);
+	const subtitleProfiles = buildSubtitleProfiles({relaxedPlaybackProfile, forceSubtitleBurnIn});
 
 	payload.EnableDirectPlay = !forceTranscoding;
 	payload.EnableDirectStream = !forceTranscoding;
@@ -223,21 +369,24 @@ export const buildPlaybackRequestContext = (options = {}) => {
 	payload.AllowAudioStreamCopy = allowStreamCopy;
 	payload.AutoOpenLiveStream = true;
 	if (maxBitrateSetting) {
-		payload.MaxStreamingBitrate = maxBitrateSetting * 1000000; // convert Mbps to bps
+		payload.MaxStreamingBitrate = maxBitrateSetting * 1000000;
 	}
 	payload.DeviceProfile = buildPlaybackDeviceProfile({
 		relaxedPlaybackProfile,
 		maxBitrateSetting,
 		directPlayProfiles,
 		transcodingProfiles,
-		subtitleProfiles
+		subtitleProfiles,
+		playbackCapabilities,
+		dynamicRangeCap
 	});
 
 	return {
 		payload,
 		forceTranscoding,
 		enableTranscoding,
-		requestedAudioStreamIndex
+		requestedAudioStreamIndex,
+		forceSubtitleBurnIn,
+		dynamicRangeCap
 	};
 };
-

--- a/src/services/jellyfin/playbackProfileBuilder.js
+++ b/src/services/jellyfin/playbackProfileBuilder.js
@@ -349,7 +349,6 @@ export const buildPlaybackRequestContext = (options = {}) => {
 	const enableTranscoding = options.enableTranscoding !== false;
 	const forceSubtitleBurnIn = options.forceSubtitleBurnIn === true;
 	const dynamicRangeCap = normalizeDynamicRangeCap(options.dynamicRangeCap);
-	// Keep stream copy available on transcode sessions unless explicitly disabled.
 	const allowStreamCopyOnTranscode = options.allowStreamCopyOnTranscode !== false;
 	const allowStreamCopy = enableTranscoding && (!forceTranscoding || allowStreamCopyOnTranscode);
 	const maxBitrateSetting = options.maxBitrate ? parseInt(options.maxBitrate, 10) : null;

--- a/src/services/serverManager.js
+++ b/src/services/serverManager.js
@@ -1,6 +1,3 @@
-// Simple multi-server manager for storing multiple Jellyfin servers and users.
-// Persists to localStorage so we can reconnect or switch without re-entering credentials.
-
 const SERVERS_KEY = 'breezyfin_servers';
 const ACTIVE_SERVER_KEY = 'breezyfin_active_server';
 const ACTIVE_USER_KEY = 'breezyfin_active_user';
@@ -71,7 +68,6 @@ const addServer = ({ serverUrl, serverName, userId, username, accessToken, avata
 
 	const servers = loadServers();
 
-	// Find existing server by URL
 	let serverId = Object.keys(servers).find((key) => servers[key].url === serverUrl) || null;
 	if (!serverId) {
 		serverId = generateId('srv');
@@ -169,7 +165,6 @@ const listServers = () => {
 		});
 	});
 
-	// Sort by last connected, most recent first
 	return result.sort((a, b) => (b.lastConnected || '').localeCompare(a.lastConnected || ''));
 };
 

--- a/src/utils/keyCodes.js
+++ b/src/utils/keyCodes.js
@@ -1,6 +1,3 @@
-// Centralized key code definitions for webOS remotes and keyboards.
-// Having a single source of truth keeps navigation/controls consistent.
-
 export const KeyCodes = {
 	LEFT: 37,
 	UP: 38,

--- a/src/utils/mediaItemUtils.js
+++ b/src/utils/mediaItemUtils.js
@@ -72,7 +72,6 @@ export const getMediaItemSubtitle = (item, {includePersonRole = false} = {}) => 
 	}
 };
 
-// Poster-ish card art for grid/list cards in Favorites/Search/Library.
 export const getPosterCardImageUrl = (item, {maxWidth = 400, personMaxWidth = 200, includeBackdrop = true, includeSeriesFallback = true} = {}) => {
 	if (!item || !canBuildImageUrl()) return null;
 
@@ -103,7 +102,6 @@ export const getPosterCardImageUrl = (item, {maxWidth = 400, personMaxWidth = 20
 	return buildPrimaryImageUrl(item.Id, {maxWidth});
 };
 
-// Landscape art for Home/MediaRow style cards.
 export const getLandscapeCardImageUrl = (item, {width = 640, includeSeriesBackdrop = true} = {}) => {
 	if (!item || !canBuildImageUrl()) return '';
 

--- a/src/utils/platformCapabilities.js
+++ b/src/utils/platformCapabilities.js
@@ -1,7 +1,70 @@
 import webOSPlatform from '@enact/webos/platform';
+import {readBreezyfinSettings} from './settingsStorage';
 
 let runtimeCapabilitiesCache = null;
 let runtimeCapabilitiesNeedsDomProbe = false;
+const RUNTIME_CAPABILITIES_CACHE_KEY = 'breezyfinRuntimeCapabilities:v2';
+const RUNTIME_CAPABILITIES_CACHE_VERSION = 2;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RUNTIME_CAPABILITIES_CACHE_TTL_DAYS = 30;
+const MIN_RUNTIME_CAPABILITIES_CACHE_TTL_DAYS = 1;
+const MAX_RUNTIME_CAPABILITIES_CACHE_TTL_DAYS = 365;
+let runtimeCapabilitiesCacheTtlMs = DEFAULT_RUNTIME_CAPABILITIES_CACHE_TTL_DAYS * DAY_MS;
+let runtimeCapabilitiesCacheTtlInitialized = false;
+const CHROME_TO_WEBOS = [
+	[120, 25],
+	[108, 24],
+	[94, 23],
+	[87, 22],
+	[79, 6],
+	[68, 5],
+	[53, 4],
+	[38, 3],
+	[34, 2],
+	[26, 1]
+];
+
+const getStorage = () => {
+	if (typeof window === 'undefined') return null;
+	try {
+		return window.localStorage;
+	} catch (_) {
+		return null;
+	}
+};
+
+const normalizeRuntimeCapabilitiesRefreshDays = (value) => {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) return DEFAULT_RUNTIME_CAPABILITIES_CACHE_TTL_DAYS;
+	const rounded = Math.trunc(parsed);
+	if (rounded < MIN_RUNTIME_CAPABILITIES_CACHE_TTL_DAYS || rounded > MAX_RUNTIME_CAPABILITIES_CACHE_TTL_DAYS) {
+		return DEFAULT_RUNTIME_CAPABILITIES_CACHE_TTL_DAYS;
+	}
+	return rounded;
+};
+
+const applyRuntimeCapabilitiesCacheTtlDays = (daysValue) => {
+	const days = normalizeRuntimeCapabilitiesRefreshDays(daysValue);
+	runtimeCapabilitiesCacheTtlMs = days * DAY_MS;
+	runtimeCapabilitiesCacheTtlInitialized = true;
+	if (runtimeCapabilitiesCache?.capabilityProbe && Number.isFinite(runtimeCapabilitiesCache.capabilityProbe.checkedAt)) {
+		runtimeCapabilitiesCache = {
+			...runtimeCapabilitiesCache,
+			capabilityProbe: {
+				...runtimeCapabilitiesCache.capabilityProbe,
+				ttlMs: runtimeCapabilitiesCacheTtlMs,
+				nextRefreshAt: runtimeCapabilitiesCache.capabilityProbe.checkedAt + runtimeCapabilitiesCacheTtlMs
+			}
+		};
+	}
+	return days;
+};
+
+const ensureRuntimeCapabilitiesCacheTtlInitialized = () => {
+	if (runtimeCapabilitiesCacheTtlInitialized) return;
+	const settings = readBreezyfinSettings();
+	applyRuntimeCapabilitiesCacheTtlDays(settings?.capabilityProbeRefreshDays);
+};
 
 const parseMajorVersion = (value) => {
 	if (value == null) return null;
@@ -13,6 +76,23 @@ const parseMajorVersion = (value) => {
 	if (!match) return null;
 	const parsed = Number(match[1]);
 	return Number.isFinite(parsed) ? parsed : null;
+};
+
+const normalizeWebOSVersionCandidate = (value) => {
+	if (!Number.isFinite(value)) return null;
+	if (value >= 7 && value <= 15) return value + 15;
+	return value;
+};
+
+const isPlausibleWebOSVersion = (value) => Number.isFinite(value) && value >= 1 && value <= 30;
+
+const mapChromeToWebOSVersion = (chromeVersion) => {
+	for (const [chrome, webosVersion] of CHROME_TO_WEBOS) {
+		if (chromeVersion >= chrome) {
+			return webosVersion;
+		}
+	}
+	return null;
 };
 
 const parseDeviceInfoVersion = () => {
@@ -28,9 +108,7 @@ const parseDeviceInfoVersion = () => {
 			deviceInfo?.sdkVersion,
 			deviceInfo?.platformVersion,
 			deviceInfo?.webosVersion,
-			deviceInfo?.version,
-			webOSSystem?.platformVersion,
-			webOSSystem?.version
+			webOSSystem?.platformVersion
 		];
 		for (const candidate of preferredCandidates) {
 			const parsed = parseMajorVersion(candidate);
@@ -46,12 +124,214 @@ const parseDeviceInfoVersion = () => {
 		}
 		return null;
 	} catch (_) {
-		return parseMajorVersion(webOSSystem.platformVersion) ?? parseMajorVersion(webOSSystem.version);
+		return parseMajorVersion(webOSSystem.platformVersion);
 	}
 };
 
 const parseWebOSVersionFromPlatform = () => {
 	return parseMajorVersion(webOSPlatform?.version);
+};
+
+const buildRuntimeSignature = () => {
+	const hasWebOSGlobals = typeof window !== 'undefined' && Boolean(window.webOSSystem || window.PalmSystem);
+	const chrome = Number(webOSPlatform?.chrome);
+	const hasChromeVersion = Number.isFinite(chrome);
+	const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+	return JSON.stringify({
+		webos: Boolean(webOSPlatform?.webos || hasWebOSGlobals),
+		platformVersion: webOSPlatform?.version ?? null,
+		chrome: hasChromeVersion ? chrome : null,
+		deviceVersion: normalizeWebOSVersionCandidate(parseDeviceInfoVersion()),
+		userAgent
+	});
+};
+
+const canPlayVideoType = (type) => {
+	if (typeof document === 'undefined') return null;
+	const video = document.createElement('video');
+	if (!video?.canPlayType) return null;
+	try {
+		const result = video.canPlayType(type);
+		return result === 'probably' || result === 'maybe';
+	} catch (_) {
+		return null;
+	}
+};
+
+const detectCodecSupport = (types) => {
+	let sawSignal = false;
+	for (const type of types) {
+		const supported = canPlayVideoType(type);
+		if (supported == null) continue;
+		sawSignal = true;
+		if (supported) return true;
+	}
+	return sawSignal ? false : null;
+};
+
+const hasPlaybackCapabilitiesShape = (value) => {
+	return Boolean(
+		value &&
+		typeof value === 'object' &&
+		value.playback &&
+		typeof value.playback === 'object'
+	);
+};
+
+const stripCapabilityProbeMetadata = (capabilities) => {
+	if (!capabilities || typeof capabilities !== 'object') return capabilities;
+	const sanitized = {...capabilities};
+	delete sanitized.capabilityProbe;
+	return sanitized;
+};
+
+const withCapabilityProbeMetadata = (capabilities, source, checkedAt) => {
+	const resolvedCheckedAt = Number.isFinite(checkedAt) ? checkedAt : Date.now();
+	const ttlMs = runtimeCapabilitiesCacheTtlMs;
+	return {
+		...capabilities,
+		capabilityProbe: {
+			source,
+			checkedAt: resolvedCheckedAt,
+			nextRefreshAt: resolvedCheckedAt + ttlMs,
+			ttlMs
+		}
+	};
+};
+
+const readCachedRuntimeCapabilities = (signature) => {
+	const storage = getStorage();
+	if (!storage) return null;
+	try {
+		const raw = storage.getItem(RUNTIME_CAPABILITIES_CACHE_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw);
+		if (parsed?.version !== RUNTIME_CAPABILITIES_CACHE_VERSION) return null;
+		if (parsed?.signature !== signature) return null;
+		if (!Number.isFinite(parsed?.checkedAt)) return null;
+		if ((Date.now() - parsed.checkedAt) > runtimeCapabilitiesCacheTtlMs) return null;
+		if (!hasPlaybackCapabilitiesShape(parsed?.capabilities)) return null;
+		return {
+			capabilities: parsed.capabilities,
+			checkedAt: parsed.checkedAt
+		};
+	} catch (_) {
+		return null;
+	}
+};
+
+const writeCachedRuntimeCapabilities = (signature, capabilities, checkedAt) => {
+	const storage = getStorage();
+	if (!storage) return;
+	try {
+		storage.setItem(
+			RUNTIME_CAPABILITIES_CACHE_KEY,
+			JSON.stringify({
+				version: RUNTIME_CAPABILITIES_CACHE_VERSION,
+				signature,
+				checkedAt,
+				capabilities: stripCapabilityProbeMetadata(capabilities)
+			})
+		);
+	} catch (_) {
+		// Ignore write failures (quota/private mode)
+	}
+};
+
+const buildPlaybackCapabilitySnapshot = ({
+	webos,
+	version,
+	chrome,
+	hasChromeVersion
+}) => {
+	const webosVersion = Number.isFinite(version) ? version : (hasChromeVersion ? mapChromeToWebOSVersion(chrome) : null);
+	const versionBucket = Number.isFinite(webosVersion) ? webosVersion : 0;
+	const webos25Plus = webos && (
+		versionBucket >= 25 ||
+		(hasChromeVersion && chrome >= 120)
+	);
+	const hevcProbe = detectCodecSupport([
+		'video/mp4; codecs="hvc1.1.6.L93.B0"',
+		'video/mp4; codecs="hev1.1.6.L93.B0"',
+		'video/mp4; codecs="hvc1"'
+	]);
+	const av1Probe = detectCodecSupport([
+		'video/mp4; codecs="av01.0.08M.08"',
+		'video/webm; codecs="av01.0.08M.08"'
+	]);
+	const vp9Probe = detectCodecSupport([
+		'video/webm; codecs="vp9"',
+		'video/mp4; codecs="vp09.00.10.08"'
+	]);
+	const ac3Probe = detectCodecSupport([
+		'audio/mp4; codecs="ac-3"',
+		'audio/mp4; codecs="ac3"'
+	]);
+	const eac3Probe = detectCodecSupport([
+		'audio/mp4; codecs="ec-3"',
+		'audio/mp4; codecs="dec3"'
+	]);
+	const atmosProbe = detectCodecSupport([
+		'audio/mp4; codecs="ec+3"'
+	]);
+	const dolbyVisionProbe = detectCodecSupport([
+		'video/mp4; codecs="dvh1.05.06"',
+		'video/mp4; codecs="dvhe.05.06"',
+		'video/mp4; codecs="dvh1"',
+		'video/mp4; codecs="dvhe"'
+	]);
+
+	const supportsHevc = hevcProbe != null ? hevcProbe : (webos && versionBucket >= 4);
+	const supportsAv1 = av1Probe != null ? av1Probe : (webos && versionBucket >= 5);
+	const supportsVp9 = vp9Probe != null ? vp9Probe : (webos && versionBucket >= 4);
+	const supportsAc3 = ac3Probe != null ? ac3Probe : webos;
+	const supportsEac3 = eac3Probe != null ? eac3Probe : webos;
+	const supportsDolbyVision = Boolean(dolbyVisionProbe || webos25Plus);
+	const supportsAtmos = atmosProbe != null ? atmosProbe : null;
+	const supportsOpus = webos && versionBucket >= 24;
+
+	const commonAudioCodecs = ['aac', 'mp3', 'mp2'];
+	if (supportsAc3) commonAudioCodecs.push('ac3');
+	if (supportsEac3) commonAudioCodecs.push('eac3');
+	const pcmAudioCodecs = ['pcm_s16le', 'pcm_s24le'];
+	const mkvAudioCodecs = supportsOpus
+		? [...commonAudioCodecs, ...pcmAudioCodecs, 'flac', 'opus']
+		: [...commonAudioCodecs, ...pcmAudioCodecs, 'flac'];
+	const mp4AudioCodecs = [...commonAudioCodecs];
+	const tsAudioCodecs = supportsOpus
+		? [...commonAudioCodecs, ...pcmAudioCodecs, 'opus']
+		: [...commonAudioCodecs, ...pcmAudioCodecs];
+
+	return {
+		webosVersion,
+		webos25Plus,
+		supportsHevc,
+		supportsAv1,
+		supportsVp9,
+		supportsAc3,
+		supportsEac3,
+		supportsAtmos,
+		supportsHdr10: webos && versionBucket >= 4,
+		supportsHlg: webos && versionBucket >= 4,
+		supportsDolbyVision,
+		supportsDolbyVisionInMkv: webos25Plus,
+		supportsDts: false,
+		supportsTrueHd: false,
+		nativeHls: webos,
+		nativeHlsFmp4: webos && versionBucket >= 5,
+		maxAudioChannels: webos25Plus ? 8 : 6,
+		maxStreamingBitrate: webos && versionBucket >= 24 ? 120000000 : 100000000,
+		audioCodecs: Array.from(new Set([...commonAudioCodecs, ...pcmAudioCodecs, ...(supportsOpus ? ['opus'] : []), 'flac'])),
+		audioCodecsByContainer: {
+			mp4: mp4AudioCodecs,
+			m4v: mp4AudioCodecs,
+			mov: mp4AudioCodecs,
+			mkv: mkvAudioCodecs,
+			ts: tsAudioCodecs,
+			mpegts: tsAudioCodecs,
+			hls: tsAudioCodecs
+		}
+	};
 };
 
 const detectFlexGapSupport = () => {
@@ -85,19 +365,32 @@ const detectBackdropFilterSupport = () => {
 const computeRuntimePlatformCapabilities = () => {
 	const hasWebOSGlobals = typeof window !== 'undefined' && Boolean(window.webOSSystem || window.PalmSystem);
 	const webos = Boolean(webOSPlatform?.webos || hasWebOSGlobals);
-	const platformVersion = parseWebOSVersionFromPlatform();
-	const deviceVersion = parseDeviceInfoVersion();
+	const platformVersion = normalizeWebOSVersionCandidate(parseWebOSVersionFromPlatform());
+	const deviceVersion = normalizeWebOSVersionCandidate(parseDeviceInfoVersion());
 	let version = platformVersion ?? deviceVersion;
-	if (platformVersion != null && deviceVersion != null && platformVersion !== deviceVersion) {
-		// Prefer user-facing version buckets (>= 3) when one source reports legacy low major values.
-		if (platformVersion <= 2 && deviceVersion >= 3) {
-			version = deviceVersion;
-		} else if (deviceVersion <= 2 && platformVersion >= 3) {
-			version = platformVersion;
-		}
-	}
 	const chrome = Number(webOSPlatform?.chrome);
 	const hasChromeVersion = Number.isFinite(chrome);
+	const chromeDerivedVersion = hasChromeVersion ? mapChromeToWebOSVersion(chrome) : null;
+	const normalizedChromeVersion = normalizeWebOSVersionCandidate(chromeDerivedVersion);
+	const candidateVersions = [platformVersion, deviceVersion, normalizedChromeVersion]
+		.filter((candidate) => candidate != null);
+	const plausibleCandidates = candidateVersions.filter(isPlausibleWebOSVersion);
+	if (plausibleCandidates.length > 0) {
+		if (isPlausibleWebOSVersion(normalizedChromeVersion)) {
+			version = plausibleCandidates.reduce((best, candidate) => {
+				if (best == null) return candidate;
+				const candidateDistance = Math.abs(candidate - normalizedChromeVersion);
+				const bestDistance = Math.abs(best - normalizedChromeVersion);
+				if (candidateDistance < bestDistance) return candidate;
+				if (candidateDistance === bestDistance && candidate > best) return candidate;
+				return best;
+			}, null);
+		} else {
+			version = Math.max(...plausibleCandidates);
+		}
+	} else if (candidateVersions.length > 0) {
+		version = candidateVersions[0];
+	}
 	const webosV6Compat = webos && (
 		(Number.isFinite(version) && version <= 6) ||
 		(hasChromeVersion && chrome <= 79)
@@ -115,6 +408,12 @@ const computeRuntimePlatformCapabilities = () => {
 	);
 	const flexGapSupport = detectFlexGapSupport();
 	runtimeCapabilitiesNeedsDomProbe = flexGapSupport == null;
+	const playback = buildPlaybackCapabilitySnapshot({
+		webos,
+		version,
+		chrome,
+		hasChromeVersion
+	});
 
 	return {
 		webos,
@@ -125,15 +424,39 @@ const computeRuntimePlatformCapabilities = () => {
 		legacyWebOS: isLegacyWebOS,
 		supportsFlexGap: flexGapSupport ?? true,
 		supportsAspectRatio,
-		supportsBackdropFilter: detectBackdropFilterSupport()
+		supportsBackdropFilter: detectBackdropFilterSupport(),
+		playback
 	};
 };
 
 export const getRuntimePlatformCapabilities = () => {
+	ensureRuntimeCapabilitiesCacheTtlInitialized();
 	const canRunDeferredDomProbe = typeof document !== 'undefined' && Boolean(document.body);
 	const shouldRefreshForDomProbe = runtimeCapabilitiesNeedsDomProbe && canRunDeferredDomProbe;
-	if (!runtimeCapabilitiesCache || shouldRefreshForDomProbe) {
-		runtimeCapabilitiesCache = computeRuntimePlatformCapabilities();
+	if (runtimeCapabilitiesCache && !shouldRefreshForDomProbe) {
+		const cachedCheckedAt = Number(runtimeCapabilitiesCache?.capabilityProbe?.checkedAt);
+		const isFresh = Number.isFinite(cachedCheckedAt)
+			? (Date.now() - cachedCheckedAt) <= runtimeCapabilitiesCacheTtlMs
+			: true;
+		if (isFresh) return runtimeCapabilitiesCache;
+		runtimeCapabilitiesCache = null;
+	}
+
+	const signature = buildRuntimeSignature();
+	if (!runtimeCapabilitiesCache && !shouldRefreshForDomProbe) {
+		const cachedEntry = readCachedRuntimeCapabilities(signature);
+		if (cachedEntry) {
+			runtimeCapabilitiesNeedsDomProbe = false;
+			runtimeCapabilitiesCache = withCapabilityProbeMetadata(cachedEntry.capabilities, 'cache', cachedEntry.checkedAt);
+			return runtimeCapabilitiesCache;
+		}
+	}
+
+	const computedCapabilities = computeRuntimePlatformCapabilities();
+	const checkedAt = Date.now();
+	runtimeCapabilitiesCache = withCapabilityProbeMetadata(computedCapabilities, 'probe', checkedAt);
+	if (!runtimeCapabilitiesNeedsDomProbe) {
+		writeCachedRuntimeCapabilities(signature, computedCapabilities, checkedAt);
 	}
 	return runtimeCapabilitiesCache;
 };
@@ -141,4 +464,22 @@ export const getRuntimePlatformCapabilities = () => {
 export const resetRuntimePlatformCapabilitiesCache = () => {
 	runtimeCapabilitiesCache = null;
 	runtimeCapabilitiesNeedsDomProbe = false;
+};
+
+export const setRuntimeCapabilityProbeRefreshDays = (daysValue) => {
+	return applyRuntimeCapabilitiesCacheTtlDays(daysValue);
+};
+
+export const getRuntimeCapabilityProbeRefreshDays = () => {
+	ensureRuntimeCapabilitiesCacheTtlInitialized();
+	return Math.max(
+		MIN_RUNTIME_CAPABILITIES_CACHE_TTL_DAYS,
+		Math.round(runtimeCapabilitiesCacheTtlMs / DAY_MS)
+	);
+};
+
+export const refreshRuntimePlatformCapabilities = () => {
+	ensureRuntimeCapabilitiesCacheTtlInitialized();
+	runtimeCapabilitiesCache = null;
+	return getRuntimePlatformCapabilities();
 };

--- a/src/utils/playbackDynamicRange.js
+++ b/src/utils/playbackDynamicRange.js
@@ -1,0 +1,167 @@
+const normalizeToken = (value) => (value || '').toString().trim().toUpperCase();
+
+export const normalizeDynamicRangeCap = (value) => {
+	const normalized = (value || '').toString().trim().toLowerCase();
+	if (normalized === 'hdr10' || normalized === 'sdr') return normalized;
+	return 'auto';
+};
+
+export const normalizeVideoRangeType = (value) => normalizeToken(value);
+
+export const isDolbyVisionRangeType = (rangeType) => {
+	const normalized = normalizeVideoRangeType(rangeType);
+	return normalized.includes('DOVI') || normalized.includes('DOLBY');
+};
+
+export const getDolbyVisionFallbackLayer = (rangeType) => {
+	const normalized = normalizeVideoRangeType(rangeType);
+	if (!normalized.includes('DOVIWITH')) return null;
+	if (normalized.includes('HDR10PLUS') || normalized.includes('HDR10+')) return 'HDR10+';
+	if (normalized.includes('HDR10') || normalized.includes('HDR')) return 'HDR10';
+	if (normalized.includes('HLG')) return 'HLG';
+	if (normalized.includes('SDR')) return 'SDR';
+	return null;
+};
+
+const resolveVideoStream = (value) => {
+	if (!value) return null;
+	if (value.Type === 'Video') return value;
+	if (Array.isArray(value.MediaStreams)) {
+		return value.MediaStreams.find((stream) => stream.Type === 'Video') || null;
+	}
+	return null;
+};
+
+export const getDynamicRangeInfo = (mediaSourceOrVideoStream) => {
+	const videoStream = resolveVideoStream(mediaSourceOrVideoStream);
+	if (!videoStream) {
+		return {
+			id: 'SDR',
+			label: 'SDR',
+			displayLabel: 'SDR',
+			rangeType: '',
+			videoRange: '',
+			isDolbyVision: false,
+			isPureDolbyVision: false,
+			hasFallbackLayer: false,
+			fallbackLayer: null
+		};
+	}
+
+	const rangeType = normalizeVideoRangeType(videoStream.VideoRangeType);
+	const videoRange = normalizeToken(videoStream.VideoRange);
+	const isDolbyVision = isDolbyVisionRangeType(rangeType);
+	const fallbackLayer = getDolbyVisionFallbackLayer(rangeType);
+	const hasFallbackLayer = fallbackLayer != null;
+
+	if (isDolbyVision) {
+		return {
+			id: 'DV',
+			label: 'Dolby Vision',
+			displayLabel: 'Dolby Vision',
+			rangeType,
+			videoRange,
+			isDolbyVision: true,
+			isPureDolbyVision: !hasFallbackLayer,
+			hasFallbackLayer,
+			fallbackLayer
+		};
+	}
+
+	if (rangeType.includes('HDR10PLUS') || rangeType.includes('HDR10+')) {
+		return {
+			id: 'HDR10_PLUS',
+			label: 'HDR10+',
+			displayLabel: 'HDR10+',
+			rangeType,
+			videoRange,
+			isDolbyVision: false,
+			isPureDolbyVision: false,
+			hasFallbackLayer: false,
+			fallbackLayer: null
+		};
+	}
+
+	if (rangeType.includes('HDR10') || rangeType === 'HDR' || rangeType.includes('HDR')) {
+		return {
+			id: 'HDR10',
+			label: 'HDR10',
+			displayLabel: 'HDR10',
+			rangeType,
+			videoRange,
+			isDolbyVision: false,
+			isPureDolbyVision: false,
+			hasFallbackLayer: false,
+			fallbackLayer: null
+		};
+	}
+
+	if (rangeType.includes('HLG')) {
+		return {
+			id: 'HLG',
+			label: 'HLG',
+			displayLabel: 'HLG',
+			rangeType,
+			videoRange,
+			isDolbyVision: false,
+			isPureDolbyVision: false,
+			hasFallbackLayer: false,
+			fallbackLayer: null
+		};
+	}
+
+	if (videoRange === 'HDR') {
+		return {
+			id: 'HDR10',
+			label: 'HDR',
+			displayLabel: 'HDR',
+			rangeType,
+			videoRange,
+			isDolbyVision: false,
+			isPureDolbyVision: false,
+			hasFallbackLayer: false,
+			fallbackLayer: null
+		};
+	}
+
+	return {
+		id: 'SDR',
+		label: 'SDR',
+		displayLabel: 'SDR',
+		rangeType,
+		videoRange,
+		isDolbyVision: false,
+		isPureDolbyVision: false,
+		hasFallbackLayer: false,
+		fallbackLayer: null
+	};
+};
+
+export const canDynamicRangeSatisfyCap = (dynamicRangeInfo, dynamicRangeCap = 'auto') => {
+	const cap = normalizeDynamicRangeCap(dynamicRangeCap);
+	const info = dynamicRangeInfo || getDynamicRangeInfo(null);
+
+	if (cap === 'auto') return true;
+	if (cap === 'sdr') {
+		if (info.id === 'SDR') return true;
+		return info.id === 'DV' && info.fallbackLayer === 'SDR';
+	}
+
+	if (info.id !== 'DV') return true;
+	if (!info.hasFallbackLayer) return false;
+	return ['HDR10', 'HDR10+', 'HLG', 'SDR'].includes(info.fallbackLayer);
+};
+
+export const getDynamicRangeDisplayLabel = (dynamicRangeInfo, dynamicRangeCap = 'auto') => {
+	const cap = normalizeDynamicRangeCap(dynamicRangeCap);
+	const info = dynamicRangeInfo || getDynamicRangeInfo(null);
+
+	if (cap === 'sdr') return 'SDR';
+	if (cap === 'hdr10' && info.id === 'DV') {
+		if (info.fallbackLayer === 'HDR10+' || info.fallbackLayer === 'HDR10') return 'HDR10 fallback';
+		if (info.fallbackLayer === 'HLG') return 'HLG fallback';
+		if (info.fallbackLayer === 'SDR') return 'SDR fallback';
+		return 'HDR fallback';
+	}
+	return info.displayLabel || info.label || 'SDR';
+};

--- a/src/views/MediaDetailsPanel.js
+++ b/src/views/MediaDetailsPanel.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Panel } from '../components/BreezyPanels';
 import Scroller from '../components/AppScroller';
 import Spinner from '@enact/sandstone/Spinner';
+import Icon from '@enact/sandstone/Icon';
 import jellyfinService from '../services/jellyfinService';
 import {KeyCodes} from '../utils/keyCodes';
 import {
@@ -59,6 +60,9 @@ const MEDIA_DETAILS_DISCLOSURE_KEY_LIST = [
 	MEDIA_DETAILS_DISCLOSURE_KEYS.SUBTITLE_PICKER,
 	MEDIA_DETAILS_DISCLOSURE_KEYS.EPISODE_PICKER
 ];
+const SECTION_SNAP_TOLERANCE_PX = 8;
+const SECTION_WHEEL_DELTA_THRESHOLD = 18;
+const SECTION_SNAP_THRESHOLD_RATIO = 0.45;
 
 const MediaDetailsPanel = ({
 	item,
@@ -144,6 +148,8 @@ const MediaDetailsPanel = ({
 	const audioSelectorButtonRef = useRef(null);
 	const subtitleSelectorButtonRef = useRef(null);
 	const playPrimaryButtonRef = useRef(null);
+	const firstSectionRef = useRef(null);
+	const contentSectionRef = useRef(null);
 	const debugLastScrollTopRef = useRef(null);
 	const debugLastScrollTimeRef = useRef(0);
 	const playbackInfoRequestRef = useRef(0);
@@ -567,15 +573,252 @@ const MediaDetailsPanel = ({
 	const overviewPlayLabel = item?.Type === 'Series'
 		? seriesPlayLabel
 		: (shouldShowContinue ? 'Continue' : 'Play');
+	const hasSecondarySection = useMemo(() => {
+		if (Array.isArray(cast) && cast.length > 0) return true;
+		if (item?.Type === 'Series') return seasons.length > 0 || episodes.length > 0;
+		return false;
+	}, [cast, episodes.length, item?.Type, seasons.length]);
 
 	const captureDetailsScrollTo = useCallback((fn) => {
 		detailsScrollToRef.current = fn;
 		captureDetailsScrollRestore(fn);
 	}, [captureDetailsScrollRestore]);
 
+	const getContentSectionTop = useCallback(() => {
+		const scrollEl = getDetailsScrollElement();
+		const contentSection = contentSectionRef.current;
+		if (!scrollEl || !contentSection) return null;
+		const scrollRect = scrollEl.getBoundingClientRect();
+		const contentRect = contentSection.getBoundingClientRect();
+		return Math.max(0, scrollEl.scrollTop + (contentRect.top - scrollRect.top));
+	}, [getDetailsScrollElement]);
+
+	const focusSectionOnePrimary = useCallback(() => {
+		if (focusTopHeaderAction()) return true;
+		if (focusNonSeriesPrimaryPlay()) return true;
+		if (focusNonSeriesAudioSelector()) return true;
+		return focusNonSeriesSubtitleSelector();
+	}, [
+		focusNonSeriesAudioSelector,
+		focusNonSeriesPrimaryPlay,
+		focusNonSeriesSubtitleSelector,
+		focusTopHeaderAction
+	]);
+
+	const focusSectionOnePrimaryFromTopNav = useCallback(() => {
+		const candidateTargets = [
+			favoriteActionButtonRef.current?.nodeRef?.current || favoriteActionButtonRef.current,
+			watchedActionButtonRef.current?.nodeRef?.current || watchedActionButtonRef.current,
+			audioSelectorButtonRef.current?.nodeRef?.current || audioSelectorButtonRef.current,
+			subtitleSelectorButtonRef.current?.nodeRef?.current || subtitleSelectorButtonRef.current,
+			playPrimaryButtonRef.current?.nodeRef?.current || playPrimaryButtonRef.current
+		];
+		for (const target of candidateTargets) {
+			if (!target?.focus) continue;
+			focusNodeWithoutScroll(target);
+			return true;
+		}
+		const introRoot = firstSectionRef.current;
+		if (introRoot) {
+			const fallbackTarget = introRoot.querySelector(
+				`.${css.actionButton}, .${css.trackSelectorPrimary}, .${css.primaryButton}, .bf-button, .spottable`
+			);
+			if (fallbackTarget?.focus) {
+				focusNodeWithoutScroll(fallbackTarget);
+				return true;
+			}
+		}
+		return focusSectionOnePrimary();
+	}, [
+		audioSelectorButtonRef,
+		favoriteActionButtonRef,
+		focusNodeWithoutScroll,
+		focusSectionOnePrimary,
+		playPrimaryButtonRef,
+		subtitleSelectorButtonRef,
+		watchedActionButtonRef
+	]);
+
+	const focusIntroTopNavigation = useCallback(() => {
+		const introRoot = firstSectionRef.current;
+		if (!introRoot) return false;
+		const breadcrumbTarget = introRoot.querySelector('[data-bf-md-nav="breadcrumb"]');
+		if (breadcrumbTarget?.focus) {
+			focusNodeWithoutScroll(breadcrumbTarget);
+			return true;
+		}
+		const backTarget = introRoot.querySelector('[data-bf-md-nav="back"]');
+		if (backTarget?.focus) {
+			focusNodeWithoutScroll(backTarget);
+			return true;
+		}
+		return false;
+	}, [focusNodeWithoutScroll]);
+
+	const focusSectionTwoPrimary = useCallback(() => {
+		if (!hasSecondarySection) return false;
+		const castTarget = contentSectionRef.current?.querySelector?.(`.${css.castToggleRow}, .${css.castCard}`);
+		if (castTarget?.focus) {
+			focusNodeWithoutScroll(castTarget);
+			return true;
+		}
+		if (focusEpisodeSelector()) return true;
+		const seasonTarget = contentSectionRef.current?.querySelector?.(`.${css.seasonCard}`);
+		if (seasonTarget?.focus) {
+			focusNodeWithoutScroll(seasonTarget);
+			return true;
+		}
+		const episodeTarget = contentSectionRef.current?.querySelector?.(`.${css.episodeCard}`);
+		if (episodeTarget?.focus) {
+			focusNodeWithoutScroll(episodeTarget);
+			return true;
+		}
+		return false;
+	}, [
+		focusEpisodeSelector,
+		focusNodeWithoutScroll,
+		hasSecondarySection
+	]);
+
+	const scrollToDetailsSection = useCallback((sectionKey, options = {}) => {
+		const {
+			animate = true,
+			focusTarget = false
+		} = options;
+		if (sectionKey === 'content' && !hasSecondarySection) return false;
+		const scrollEl = getDetailsScrollElement();
+		if (!scrollEl) return false;
+		const sectionTwoTop = getContentSectionTop();
+		if (sectionTwoTop === null) return false;
+		const nextTop = sectionKey === 'content' ? sectionTwoTop : 0;
+		if (Math.abs(scrollEl.scrollTop - nextTop) > 1) {
+			scrollEl.scrollTo({top: nextTop, behavior: animate ? 'smooth' : 'auto'});
+		}
+		if (focusTarget) {
+			window.requestAnimationFrame(() => {
+				if (sectionKey === 'content') {
+					focusSectionTwoPrimary();
+				} else {
+					focusSectionOnePrimary();
+				}
+			});
+		}
+		return true;
+	}, [
+		focusSectionOnePrimary,
+		focusSectionTwoPrimary,
+		getContentSectionTop,
+		getDetailsScrollElement,
+		hasSecondarySection
+	]);
+
+	const focusAndShowSecondSection = useCallback(() => {
+		if (!focusSectionTwoPrimary()) return false;
+		scrollToDetailsSection('content', {animate: true, focusTarget: false});
+		return true;
+	}, [focusSectionTwoPrimary, scrollToDetailsSection]);
+
+	const handleIntroActionKeyDown = useCallback((event) => {
+		const code = event.keyCode || event.which;
+		if (code !== KeyCodes.DOWN) return;
+		if (!focusAndShowSecondSection()) return;
+		event.preventDefault();
+		event.stopPropagation();
+	}, [focusAndShowSecondSection]);
+
+	const handleIntroTopNavKeyDown = useCallback((event) => {
+		if (event.defaultPrevented) return;
+		const code = event.keyCode || event.which;
+		if (code !== KeyCodes.DOWN) return;
+		event.preventDefault();
+		event.stopPropagation();
+		if (focusSectionOnePrimaryFromTopNav()) return;
+		window.requestAnimationFrame(() => {
+			focusSectionOnePrimaryFromTopNav();
+		});
+	}, [focusSectionOnePrimaryFromTopNav]);
+
+	const handleSectionWheelCapture = useCallback((event) => {
+		if (!isActive || !hasSecondarySection) return;
+		if (showAudioPicker || showSubtitlePicker || showEpisodePicker) return;
+		const scrollEl = getDetailsScrollElement();
+		const sectionTwoTop = getContentSectionTop();
+		if (!scrollEl || sectionTwoTop === null) return;
+		const deltaY = Number(event.deltaY || 0);
+		if (Math.abs(deltaY) < SECTION_WHEEL_DELTA_THRESHOLD) return;
+		const currentTop = scrollEl.scrollTop;
+		if (deltaY > 0 && currentTop < (sectionTwoTop - SECTION_SNAP_TOLERANCE_PX)) {
+			event.preventDefault();
+			event.stopPropagation();
+			scrollToDetailsSection('content');
+		} else if (deltaY < 0 && currentTop <= (sectionTwoTop + SECTION_SNAP_TOLERANCE_PX)) {
+			event.preventDefault();
+			event.stopPropagation();
+			scrollToDetailsSection('intro');
+		}
+	}, [
+		getContentSectionTop,
+		getDetailsScrollElement,
+		hasSecondarySection,
+		isActive,
+		scrollToDetailsSection,
+		showAudioPicker,
+		showEpisodePicker,
+		showSubtitlePicker
+	]);
+
+	useEffect(() => {
+		if (!isActive || !hasSecondarySection || loading) return undefined;
+		if (showAudioPicker || showSubtitlePicker || showEpisodePicker) return undefined;
+
+		const handleFocusIn = (event) => {
+			const target = event.target;
+			if (!target || target.nodeType !== 1) return;
+			const targetNode = target;
+			const scrollEl = getDetailsScrollElement();
+			const sectionTwoTop = getContentSectionTop();
+			if (!scrollEl || sectionTwoTop === null) return;
+
+			if (firstSectionRef.current?.contains(targetNode)) {
+				if (scrollEl.scrollTop > SECTION_SNAP_TOLERANCE_PX) {
+					scrollToDetailsSection('intro');
+				}
+				return;
+			}
+			if (!contentSectionRef.current?.contains(targetNode)) return;
+			if (scrollEl.scrollTop < (sectionTwoTop - SECTION_SNAP_TOLERANCE_PX)) {
+				scrollToDetailsSection('content');
+			}
+		};
+
+		document.addEventListener('focusin', handleFocusIn, true);
+		return () => document.removeEventListener('focusin', handleFocusIn, true);
+	}, [
+		getContentSectionTop,
+		getDetailsScrollElement,
+		hasSecondarySection,
+		isActive,
+		loading,
+		scrollToDetailsSection,
+		showAudioPicker,
+		showEpisodePicker,
+		showSubtitlePicker
+	]);
+
 	const handleDetailsScrollerScrollStop = useCallback((event) => {
 		handleDetailsScrollMemoryStop(event);
-	}, [handleDetailsScrollMemoryStop]);
+		if (!hasSecondarySection) return;
+		const scrollEl = getDetailsScrollElement();
+		const sectionTwoTop = getContentSectionTop();
+		if (!scrollEl || sectionTwoTop === null) return;
+		const currentTop = scrollEl.scrollTop;
+		if (currentTop <= SECTION_SNAP_TOLERANCE_PX || currentTop >= sectionTwoTop) return;
+		const snapThreshold = sectionTwoTop * SECTION_SNAP_THRESHOLD_RATIO;
+		scrollEl.scrollTo({
+			top: currentTop <= snapThreshold ? 0 : sectionTwoTop,
+			behavior: 'smooth'
+		});
+	}, [getContentSectionTop, getDetailsScrollElement, handleDetailsScrollMemoryStop, hasSecondarySection]);
 
 	const handleOpenEpisodeSeries = useCallback(() => {
 		openSeriesFromEpisode(item?.SeasonId || null);
@@ -619,6 +862,7 @@ const MediaDetailsPanel = ({
 	});
 	const {
 		handleCastCardFocus,
+		handleCastToggleKeyDown,
 		handleCastCardKeyDown,
 		handleSeasonCardClick,
 		handleSeasonCardFocus,
@@ -666,6 +910,9 @@ const MediaDetailsPanel = ({
 		focusNonSeriesSubtitleSelector,
 		focusNonSeriesPrimaryPlay,
 		focusNonSeriesAudioSelector,
+		focusIntroTopNavigation,
+		focusFirstSectionPrimary: focusSectionOnePrimary,
+		focusSecondSectionPrimary: focusAndShowSecondSection,
 		showEpisodeInfoButton: typeof onItemSelect === 'function',
 		css
 	});
@@ -734,9 +981,13 @@ const MediaDetailsPanel = ({
 		onAudioSelectorKeyDown: handleAudioSelectorKeyDown,
 		onSubtitleSelectorKeyDown: handleSubtitleSelectorKeyDown,
 		onPlay: handlePlay,
-		onNonSeriesPlayKeyDown: handleNonSeriesPlayKeyDown
+		onNonSeriesPlayKeyDown: handleNonSeriesPlayKeyDown,
+		showSectionHints: hasSecondarySection,
+		onIntroActionKeyDown: handleIntroActionKeyDown,
+		onIntroTopNavKeyDown: handleIntroTopNavKeyDown
 	};
 	const introRefs = {
+		firstSectionRef,
 		favoriteActionButtonRef,
 		watchedActionButtonRef,
 		overviewTextRef,
@@ -759,6 +1010,7 @@ const MediaDetailsPanel = ({
 						tabIndex={-1}
 						onMouseDownCapture={handleDetailsPointerDownCapture}
 						onClickCapture={handleDetailsPointerClickCapture}
+						onWheelCapture={handleSectionWheelCapture}
 				>
 					{!loading && (
 						<div className={`${css.backdrop} ${hasBackdropImage ? '' : css.backdropFallback} ${isElegantTheme ? css.backdropElegant : ''}`}>
@@ -786,11 +1038,20 @@ const MediaDetailsPanel = ({
 											refs={introRefs}
 										/>
 
-										<div className={css.contentSection}>
+										<div className={css.contentSection} ref={contentSectionRef}>
+											{hasSecondarySection && (
+												<div className={css.sectionSwitchRow}>
+													<div className={css.sectionHint}>
+														<Icon className={css.sectionHintArrow}>arrowsmallup</Icon>
+														Overview
+													</div>
+												</div>
+											)}
 									<MediaCastSection
 										cast={cast}
 										isCastCollapsed={isCastCollapsed}
 										onToggleCastCollapsed={toggleCastCollapsed}
+										onCastToggleKeyDown={handleCastToggleKeyDown}
 										castScrollerRef={castScrollerRef}
 										castRowRef={castRowRef}
 										onCastCardFocus={handleCastCardFocus}

--- a/src/views/MediaDetailsPanel.js
+++ b/src/views/MediaDetailsPanel.js
@@ -305,7 +305,6 @@ const MediaDetailsPanel = ({
 		}
 	}, [item, onPlay, playbackInfo, selectedAudioTrack, selectedEpisode, selectedSubtitleTrack]);
 
-	// Keep "Back" behavior consistent with other panels; series jump is exposed explicitly.
 	const handleBack = useCallback(() => {
 		onBack();
 	}, [onBack]);

--- a/src/views/PlayerPanel.js
+++ b/src/views/PlayerPanel.js
@@ -84,6 +84,7 @@ const PlayerPanel = ({
 	const currentSubtitleTrackRef = useRef(null);
 	const startupFallbackTimerRef = useRef(null);
 	const transcodeFallbackAttemptedRef = useRef(false);
+	const dynamicRangeFallbackAttemptedRef = useRef(false);
 	const reloadAttemptedRef = useRef(false);
 	const lastProgressRef = useRef({ time: 0, timestamp: 0 });
 	const loadVideoRef = useRef(null);
@@ -107,8 +108,9 @@ const PlayerPanel = ({
 	const playbackFailureLockedRef = useRef(false);
 	const {
 		toastMessage,
+		toastVisible,
 		setToastMessage
-	} = useToastMessage({durationMs: 2000});
+	} = useToastMessage({durationMs: 2050, fadeOutMs: 350});
 	const {
 		loadTrackPreferences,
 		pickPreferredAudio,
@@ -366,11 +368,12 @@ const PlayerPanel = ({
 		playbackOverrideRef,
 		loadVideoRef,
 		mediaSourceData,
-		playbackSettingsRef,
-		transcodeFallbackAttemptedRef,
-		subtitleCompatibilityFallbackAttemptedRef,
-		setCurrentSubtitleTrack
-	});
+			playbackSettingsRef,
+			transcodeFallbackAttemptedRef,
+			dynamicRangeFallbackAttemptedRef,
+			subtitleCompatibilityFallbackAttemptedRef,
+			setCurrentSubtitleTrack
+		});
 
 	const loadVideo = usePlayerVideoLoader({
 		item,
@@ -883,7 +886,7 @@ const PlayerPanel = ({
 					getSkipSegmentLabel={getSkipSegmentLabel}
 				/>
 
-				<PlayerToast message={toastMessage} hidden={Boolean(error)} />
+				<PlayerToast message={toastMessage} visible={toastVisible && !error} />
 
 					<PlayerControlsOverlay
 						state={playerControlsState}

--- a/src/views/favorites-panel-styles/_favorites-panel-elegant.less
+++ b/src/views/favorites-panel-styles/_favorites-panel-elegant.less
@@ -1,1 +1,0 @@
-/* FavoritesPanel: elegant-theme specific overrides. */

--- a/src/views/favorites-panel-styles/_favorites-panel-shared-tail.less
+++ b/src/views/favorites-panel-styles/_favorites-panel-shared-tail.less
@@ -1,4 +1,3 @@
-/* FavoritesPanel: shared tail overrides (input-mode/performance toggles, final normalizers). */
 :global([data-bf-animations='off']),
 :global([data-bf-all-animations='off']) {
 	.favoriteCard {

--- a/src/views/home-panel-styles/_home-panel-elegant.less
+++ b/src/views/home-panel-styles/_home-panel-elegant.less
@@ -1,1 +1,0 @@
-/* HomePanel: elegant-theme specific overrides. */

--- a/src/views/home-panel-styles/_home-panel-shared-tail.less
+++ b/src/views/home-panel-styles/_home-panel-shared-tail.less
@@ -1,1 +1,0 @@
-/* HomePanel: shared tail overrides (input-mode/performance toggles, final normalizers). */

--- a/src/views/library-panel-styles/_library-panel-elegant.less
+++ b/src/views/library-panel-styles/_library-panel-elegant.less
@@ -1,1 +1,0 @@
-/* LibraryPanel: elegant-theme specific overrides. */

--- a/src/views/library-panel-styles/_library-panel-shared-tail.less
+++ b/src/views/library-panel-styles/_library-panel-shared-tail.less
@@ -1,4 +1,3 @@
-/* LibraryPanel: shared tail overrides (input-mode/performance toggles, final normalizers). */
 :global([data-bf-animations='off']),
 :global([data-bf-all-animations='off']) {
 	.gridCard {

--- a/src/views/login-panel-styles/_login-panel-elegant.less
+++ b/src/views/login-panel-styles/_login-panel-elegant.less
@@ -1,4 +1,3 @@
-/* LoginPanel: elegant-theme specific overrides. */
 :global([data-bf-nav-theme='elegant']) {
 	.page {
 		background-color: #070d14;

--- a/src/views/login-panel-styles/_login-panel-shared-tail.less
+++ b/src/views/login-panel-styles/_login-panel-shared-tail.less
@@ -1,5 +1,3 @@
-/* LoginPanel: shared tail overrides (input-mode/performance toggles, final normalizers). */
-
 :global([data-bf-all-animations='off']) {
 	.backdropImage {
 		animation: none !important;

--- a/src/views/media-details-panel/components/MediaCastSection.js
+++ b/src/views/media-details-panel/components/MediaCastSection.js
@@ -10,6 +10,7 @@ const MediaCastSection = ({
 	cast,
 	isCastCollapsed,
 	onToggleCastCollapsed,
+	onCastToggleKeyDown,
 	castScrollerRef,
 	castRowRef,
 	onCastCardFocus,
@@ -27,6 +28,7 @@ const MediaCastSection = ({
 				aria-label={isCastCollapsed ? 'Show cast' : 'Hide cast'}
 				title={isCastCollapsed ? 'Show cast' : 'Hide cast'}
 				onClick={onToggleCastCollapsed}
+				onKeyDown={onCastToggleKeyDown}
 			>
 				<Heading size="medium" className={`${css.sectionHeading} ${css.castToggleLabel}`}>Cast</Heading>
 				<Icon className={css.castToggleIcon}>

--- a/src/views/media-details-panel/components/MediaDetailsIntroSection.js
+++ b/src/views/media-details-panel/components/MediaDetailsIntroSection.js
@@ -48,9 +48,13 @@ const MediaDetailsIntroSection = ({
 		onAudioSelectorKeyDown,
 		onSubtitleSelectorKeyDown,
 		onPlay,
-		onNonSeriesPlayKeyDown
+		onNonSeriesPlayKeyDown,
+		showSectionHints,
+		onIntroActionKeyDown,
+		onIntroTopNavKeyDown
 	} = actions;
 	const {
+		firstSectionRef,
 		favoriteActionButtonRef,
 		watchedActionButtonRef,
 		overviewTextRef,
@@ -62,15 +66,18 @@ const MediaDetailsIntroSection = ({
 	if (!item) return null;
 
 	return (
-		<div className={css.firstSection}>
+		<div className={css.firstSection} ref={firstSectionRef}>
 			<div className={css.detailsHeadingStack}>
 				<div className={css.detailsTopBar}>
 					<Button
 						size="small"
 						icon="arrowsmallleft"
 						onClick={onBack}
+						onKeyDown={onIntroTopNavKeyDown}
+						onKeyDownCapture={onIntroTopNavKeyDown}
 						className={css.detailsBackButton}
 						aria-label="Back"
+						data-bf-md-nav="back"
 					/>
 					<BodyText className={css.detailsTopTitle}>{pageTitle}</BodyText>
 				</div>
@@ -81,6 +88,9 @@ const MediaDetailsIntroSection = ({
 								size="small"
 								className={`${css.episodeNavButton} ${css.episodeSeriesButton}`}
 								onClick={onOpenEpisodeSeries}
+								onKeyDown={onIntroTopNavKeyDown}
+								onKeyDownCapture={onIntroTopNavKeyDown}
+								data-bf-md-nav="breadcrumb"
 							>
 								{item.SeriesName}
 							</Button>
@@ -91,6 +101,9 @@ const MediaDetailsIntroSection = ({
 										size="small"
 										className={css.episodeNavButton}
 										onClick={onOpenEpisodeSeries}
+										onKeyDown={onIntroTopNavKeyDown}
+										onKeyDownCapture={onIntroTopNavKeyDown}
+										data-bf-md-nav="breadcrumb"
 									>
 										Season {item.ParentIndexNumber}
 									</Button>
@@ -101,6 +114,9 @@ const MediaDetailsIntroSection = ({
 								size="small"
 								className={`${css.episodeNavButton} ${css.episodeCurrentButton}`}
 								onClick={onOpenEpisodePicker}
+								onKeyDown={onIntroTopNavKeyDown}
+								onKeyDownCapture={onIntroTopNavKeyDown}
+								data-bf-md-nav="breadcrumb"
 							>
 								Episode {item.IndexNumber}
 							</Button>
@@ -179,6 +195,7 @@ const MediaDetailsIntroSection = ({
 									size="small"
 									icon={isFavorite ? 'heart' : 'hearthollow'}
 									onClick={onToggleFavorite}
+									onKeyDown={onIntroActionKeyDown}
 									css={{icon: css.actionIcon}}
 									componentRef={favoriteActionButtonRef}
 									spotlightId="details-favorite-action"
@@ -189,6 +206,7 @@ const MediaDetailsIntroSection = ({
 									size="small"
 									icon="check"
 									onClick={onToggleWatchedMain}
+									onKeyDown={onIntroActionKeyDown}
 									css={{icon: css.actionIcon}}
 									componentRef={watchedActionButtonRef}
 									spotlightId="details-watched-action"
@@ -239,6 +257,12 @@ const MediaDetailsIntroSection = ({
 								>
 									{overviewPlayLabel}
 								</Button>
+								{showSectionHints && (
+									<BodyText className={css.sectionHint}>
+										More
+										<Icon className={css.sectionHintArrow}>arrowsmalldown</Icon>
+									</BodyText>
+								)}
 							</div>
 						</div>
 					</div>

--- a/src/views/media-details-panel/components/MediaDetailsToast.js
+++ b/src/views/media-details-panel/components/MediaDetailsToast.js
@@ -1,17 +1,7 @@
-import css from '../../MediaDetailsPanel.module.less';
+import BreezyToast from '../../../components/BreezyToast';
 
 const MediaDetailsToast = ({message, visible}) => {
-	if (!message) return null;
-
-	return (
-		<div
-			className={`${css.toast} ${visible ? css.toastVisible : ''}`}
-			role="status"
-			aria-live="polite"
-		>
-			{message}
-		</div>
-	);
+	return <BreezyToast message={message} visible={visible} />;
 };
 
 export default MediaDetailsToast;

--- a/src/views/media-details-panel/hooks/useMediaDetailsInteractionHandlers.js
+++ b/src/views/media-details-panel/hooks/useMediaDetailsInteractionHandlers.js
@@ -30,12 +30,32 @@ export const useMediaDetailsInteractionHandlers = ({
 	focusNonSeriesSubtitleSelector,
 	focusNonSeriesPrimaryPlay,
 	focusNonSeriesAudioSelector,
+	focusIntroTopNavigation,
+	focusFirstSectionPrimary,
+	focusSecondSectionPrimary,
 	showEpisodeInfoButton,
 	css
 }) => {
 	const handleCastCardFocus = useCallback((event) => {
 		scrollCastIntoView(event.currentTarget);
 	}, [scrollCastIntoView]);
+
+	const handleCastToggleKeyDown = useCallback((event) => {
+		if (event.keyCode === KeyCodes.UP) {
+			event.preventDefault();
+			event.stopPropagation();
+			if (typeof focusFirstSectionPrimary === 'function') {
+				focusFirstSectionPrimary();
+			}
+		} else if (event.keyCode === KeyCodes.DOWN) {
+			const firstCastCard = castRowRef.current?.querySelector(`.${css.castCard}`);
+			if (firstCastCard?.focus) {
+				event.preventDefault();
+				event.stopPropagation();
+				firstCastCard.focus();
+			}
+		}
+	}, [castRowRef, css.castCard, focusFirstSectionPrimary]);
 
 	const handleCastCardKeyDown = useCallback((event) => {
 		const cards = Array.from(castRowRef.current?.querySelectorAll(`.${css.castCard}`) || []);
@@ -46,8 +66,14 @@ export const useMediaDetailsInteractionHandlers = ({
 		} else if (event.keyCode === KeyCodes.RIGHT && index < cards.length - 1) {
 			event.preventDefault();
 			cards[index + 1].focus();
+		} else if (event.keyCode === KeyCodes.UP) {
+			event.preventDefault();
+			event.stopPropagation();
+			if (typeof focusFirstSectionPrimary === 'function') {
+				focusFirstSectionPrimary();
+			}
 		}
-	}, [castRowRef, css.castCard]);
+	}, [castRowRef, css.castCard, focusFirstSectionPrimary]);
 
 	const handleSeasonCardClick = useCallback((event) => {
 		const seasonId = event.currentTarget.dataset.seasonId;
@@ -129,8 +155,14 @@ export const useMediaDetailsInteractionHandlers = ({
 			event.preventDefault();
 			event.stopPropagation();
 			focusEpisodeCardByIndex(0);
+		} else if (event.keyCode === KeyCodes.UP) {
+			event.preventDefault();
+			event.stopPropagation();
+			if (typeof focusFirstSectionPrimary === 'function') {
+				focusFirstSectionPrimary();
+			}
 		}
-	}, [focusEpisodeCardByIndex]);
+	}, [focusEpisodeCardByIndex, focusFirstSectionPrimary]);
 
 	const handleEpisodeCardClick = useCallback((event) => {
 		const episodeId = event.currentTarget.dataset.episodeId;
@@ -375,6 +407,11 @@ export const useMediaDetailsInteractionHandlers = ({
 
 	const handleAudioSelectorKeyDown = useCallback((event) => {
 		if (event.keyCode === KeyCodes.DOWN) {
+			if (typeof focusSecondSectionPrimary === 'function' && focusSecondSectionPrimary()) {
+				event.preventDefault();
+				event.stopPropagation();
+				return;
+			}
 			event.preventDefault();
 			event.stopPropagation();
 			if (!focusNonSeriesSubtitleSelector()) {
@@ -383,40 +420,64 @@ export const useMediaDetailsInteractionHandlers = ({
 		} else if (event.keyCode === KeyCodes.UP) {
 			event.preventDefault();
 			event.stopPropagation();
+			if (typeof focusIntroTopNavigation === 'function' && focusIntroTopNavigation()) return;
 			focusTopHeaderAction();
 		}
-	}, [focusNonSeriesPrimaryPlay, focusNonSeriesSubtitleSelector, focusTopHeaderAction]);
+	}, [
+		focusNonSeriesPrimaryPlay,
+		focusNonSeriesSubtitleSelector,
+		focusIntroTopNavigation,
+		focusSecondSectionPrimary,
+		focusTopHeaderAction
+	]);
 
 	const handleSubtitleSelectorKeyDown = useCallback((event) => {
 		if (event.keyCode === KeyCodes.DOWN) {
+			if (typeof focusSecondSectionPrimary === 'function' && focusSecondSectionPrimary()) {
+				event.preventDefault();
+				event.stopPropagation();
+				return;
+			}
 			event.preventDefault();
 			event.stopPropagation();
 			focusNonSeriesPrimaryPlay();
 		} else if (event.keyCode === KeyCodes.UP) {
 			event.preventDefault();
 			event.stopPropagation();
-			if (!focusNonSeriesAudioSelector()) {
-				focusTopHeaderAction();
-			}
+			if (typeof focusIntroTopNavigation === 'function' && focusIntroTopNavigation()) return;
+			if (!focusNonSeriesAudioSelector()) focusTopHeaderAction();
 		}
-	}, [focusNonSeriesAudioSelector, focusNonSeriesPrimaryPlay, focusTopHeaderAction]);
+	}, [
+		focusIntroTopNavigation,
+		focusNonSeriesAudioSelector,
+		focusNonSeriesPrimaryPlay,
+		focusSecondSectionPrimary,
+		focusTopHeaderAction
+	]);
 
 	const handleNonSeriesPlayKeyDown = useCallback((event) => {
 		if (event.keyCode === KeyCodes.DOWN) {
 			event.preventDefault();
 			event.stopPropagation();
+			if (typeof focusSecondSectionPrimary === 'function' && focusSecondSectionPrimary()) return;
 			focusNonSeriesPrimaryPlay();
 		} else if (event.keyCode === KeyCodes.UP) {
 			event.preventDefault();
 			event.stopPropagation();
-			if (!focusNonSeriesSubtitleSelector()) {
-				focusNonSeriesAudioSelector();
-			}
+			if (typeof focusIntroTopNavigation === 'function' && focusIntroTopNavigation()) return;
+			if (!focusNonSeriesSubtitleSelector()) focusNonSeriesAudioSelector();
 		}
-	}, [focusNonSeriesAudioSelector, focusNonSeriesPrimaryPlay, focusNonSeriesSubtitleSelector]);
+	}, [
+		focusIntroTopNavigation,
+		focusNonSeriesAudioSelector,
+		focusNonSeriesPrimaryPlay,
+		focusNonSeriesSubtitleSelector,
+		focusSecondSectionPrimary
+	]);
 
 	return {
 		handleCastCardFocus,
+		handleCastToggleKeyDown,
 		handleCastCardKeyDown,
 		handleSeasonCardClick,
 		handleSeasonCardFocus,

--- a/src/views/media-details-styles/_media-details-base.less
+++ b/src/views/media-details-styles/_media-details-base.less
@@ -59,37 +59,6 @@
 	}
 }
 
-.toast {
-	position: fixed;
-	top: 1.25rem;
-	left: 50%;
-	transform: translate(-50%, -0.65rem);
-	opacity: 0;
-	padding: 0.72rem 1.35rem;
-	max-width: calc(100vw - 2.5rem);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	background: var(--bf-theme-message-bg, rgba(18, 24, 36, 0.86));
-	border: 1px solid var(--bf-theme-message-border, rgba(255, 255, 255, 0.22));
-	border-radius: 0.8rem;
-	color: var(--bf-theme-message-color, rgba(245, 250, 255, 0.96));
-	font-size: 0.88em;
-	font-weight: 600;
-	letter-spacing: 0.01em;
-	line-height: 1.2;
-	backdrop-filter: blur(12px);
-	box-shadow: var(--bf-theme-message-shadow, 0 0.5rem 1.4rem rgba(0, 0, 0, 0.4));
-	pointer-events: none;
-	z-index: 30;
-	transition: opacity 220ms ease, transform 220ms ease;
-}
-
-.toastVisible {
-	opacity: 1;
-	transform: translate(-50%, 0);
-}
-
 .loading {
 	display: flex;
 	justify-content: center;
@@ -323,6 +292,38 @@
 
 .contentSection {
 	padding-top: 0.45rem;
+	min-height: calc(100vh - var(--bf-md-content-top-padding, 1rem));
+}
+
+.sectionSwitchRow {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	margin: 0.2rem 0 0.8rem;
+}
+
+.sectionHint {
+	margin-left: auto;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.2rem;
+	font-size: 0.8em;
+	font-weight: 600;
+	letter-spacing: 0.03em;
+	text-transform: uppercase;
+	color: rgba(210, 222, 238, 0.78);
+	opacity: 0.9;
+}
+
+.sectionHintArrow {
+	font-size: 0.74rem !important;
+	width: 0.74rem !important;
+	height: 0.74rem !important;
+	line-height: 0.74rem !important;
+	display: inline-flex !important;
+	align-items: center !important;
+	justify-content: center !important;
+	opacity: 0.92;
 }
 
 .backdropFallback {

--- a/src/views/player-panel-styles/_player-panel-base.less
+++ b/src/views/player-panel-styles/_player-panel-base.less
@@ -218,22 +218,6 @@
 	}
 }
 
-.playerToast {
-	position: absolute;
-	left: 50%;
-	bottom: 24px;
-	transform: translateX(-50%);
-	background: var(--bf-theme-message-bg, rgba(18, 24, 36, 0.86));
-	border: 1px solid var(--bf-theme-message-border, rgba(255, 255, 255, 0.22));
-	border-radius: 10px;
-	padding: 12px 18px;
-	color: var(--bf-theme-message-color, rgba(245, 250, 255, 0.96));
-	box-shadow: var(--bf-theme-message-shadow, 0 0.5rem 1.4rem rgba(0, 0, 0, 0.4));
-	backdrop-filter: blur(0.6rem);
-	-webkit-backdrop-filter: blur(0.6rem);
-	z-index: 140;
-}
-
 .seekFeedback {
 	position: absolute;
 	left: 50%;

--- a/src/views/player-panel/components/PlayerControlsOverlay.js
+++ b/src/views/player-panel/components/PlayerControlsOverlay.js
@@ -1,7 +1,7 @@
 import Slider from '@enact/sandstone/Slider';
 import BodyText from '@enact/sandstone/BodyText';
 import Button from '../../../components/BreezyButton';
-import {formatPlaybackTime} from '../utils/playerPanelHelpers';
+import {formatPlaybackTime, getPlayerHeaderTitle} from '../utils/playerPanelHelpers';
 import css from '../../PlayerPanel.module.less';
 
 const PlayerControlsOverlay = ({
@@ -49,7 +49,7 @@ const PlayerControlsOverlay = ({
 					icon="arrowlargeleft"
 					className={css.playerBackButton}
 				/>
-				<BodyText className={css.title}>{item?.Name}</BodyText>
+				<BodyText className={css.title}>{getPlayerHeaderTitle(item)}</BodyText>
 			</div>
 
 			<div className={css.bottomBar}>

--- a/src/views/player-panel/components/PlayerToast.js
+++ b/src/views/player-panel/components/PlayerToast.js
@@ -1,8 +1,7 @@
-import css from '../../PlayerPanel.module.less';
+import BreezyToast from '../../../components/BreezyToast';
 
-const PlayerToast = ({message, hidden}) => {
-	if (!message || hidden) return null;
-	return <div className={css.playerToast}>{message}</div>;
+const PlayerToast = ({message, visible}) => {
+	return <BreezyToast message={message} visible={visible} />;
 };
 
 export default PlayerToast;

--- a/src/views/player-panel/utils/playerPanelHelpers.js
+++ b/src/views/player-panel/utils/playerPanelHelpers.js
@@ -11,6 +11,23 @@ export const formatPlaybackTime = (seconds) => {
 	return `${minutes}:${secs.toString().padStart(2, '0')}`;
 };
 
+const toPositiveInteger = (value) => {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) return null;
+	const integerValue = Math.trunc(parsed);
+	if (integerValue < 0) return null;
+	return integerValue;
+};
+
+export const getPlayerHeaderTitle = (item) => {
+	const baseTitle = item?.Name || 'Unknown title';
+	if (item?.Type !== 'Episode') return baseTitle;
+	const seasonNumber = toPositiveInteger(item?.ParentIndexNumber);
+	const episodeNumber = toPositiveInteger(item?.IndexNumber);
+	if (seasonNumber == null || episodeNumber == null) return baseTitle;
+	return `S${seasonNumber}E${episodeNumber}: ${baseTitle}`;
+};
+
 export const getPlayerTrackLabel = (track) => {
 	if (!track || typeof track !== 'object') return 'Track';
 	const parts = [];

--- a/src/views/settings-panel/components/SettingsPopups.js
+++ b/src/views/settings-panel/components/SettingsPopups.js
@@ -10,8 +10,12 @@ const SettingsPopups = ({
 	bitratePopupOpen,
 	closeBitratePopup,
 	bitrateOptions,
+	capabilityProbeRefreshPopupOpen,
+	closeCapabilityProbeRefreshPopup,
+	capabilityProbeRefreshOptions,
 	settings,
 	handleBitrateSelect,
+	handleCapabilityProbeRefreshSelect,
 	audioLangPopupOpen,
 	closeAudioLangPopup,
 	languageOptions,
@@ -84,6 +88,27 @@ const SettingsPopups = ({
 							</Button>
 						))}
 					</div>
+				</div>
+			</Popup>
+
+			<Popup
+				open={capabilityProbeRefreshPopupOpen}
+				onClose={closeCapabilityProbeRefreshPopup}
+				css={popupShellCss}
+			>
+				<div className={`${popupStyles.popupSurface} ${css.popupContent}`}>
+					<BodyText className={css.popupTitle}>Capability Probe Refresh Period</BodyText>
+					{capabilityProbeRefreshOptions.map((option) => (
+						<Button
+							key={option.value}
+							data-days={option.value}
+							className={css.popupOption}
+							selected={String(settings.capabilityProbeRefreshDays) === option.value}
+							onClick={handleCapabilityProbeRefreshSelect}
+						>
+							{option.label}
+						</Button>
+					))}
 				</div>
 			</Popup>
 

--- a/src/views/settings-panel/components/SettingsSections.js
+++ b/src/views/settings-panel/components/SettingsSections.js
@@ -34,6 +34,18 @@ const SettingsSections = ({
 	openNavbarThemePopup,
 	appVersion,
 	webosVersionLabel,
+	capabilityProbeLabel,
+	getCapabilityProbeRefreshPeriodLabel,
+	openCapabilityProbeRefreshPopup,
+	handleRefreshCapabilitiesNow,
+	dynamicRangeLabel,
+	dolbyVisionMkvLabel,
+	videoCodecsLabel,
+	audioCodecsLabel,
+	atmosLabel,
+	hdAudioLabel,
+	maxAudioChannelsLabel,
+	maxStreamingBitrateLabel,
 	openStylingDebugPanel,
 	appLogCount,
 	cacheWipeInProgress,
@@ -326,6 +338,31 @@ const SettingsSections = ({
 				<Item className={css.infoItem} label="App Version" slotAfter={appVersion} />
 				<Item className={css.infoItem} label="Platform" slotAfter="webOS TV" />
 				<Item className={css.infoItem} label="webOS Version" slotAfter={webosVersionLabel} />
+			</section>
+
+			<section className={css.section}>
+				<BodyText className={css.sectionTitle}>Device Playback Capabilities</BodyText>
+				<Item className={css.infoItem} label="Capability Probe" slotAfter={capabilityProbeLabel} />
+				<Item
+					className={css.settingItem}
+					label="Probe Refresh Period"
+					slotAfter={getCapabilityProbeRefreshPeriodLabel(settings.capabilityProbeRefreshDays)}
+					onClick={openCapabilityProbeRefreshPopup}
+				/>
+				<Item
+					className={css.settingItem}
+					label="Refresh Capabilities Now"
+					slotAfter="Run"
+					onClick={handleRefreshCapabilitiesNow}
+				/>
+				<Item className={css.infoItem} label="Dynamic Range" slotAfter={dynamicRangeLabel} />
+				<Item className={css.infoItem} label="Dolby Vision in MKV" slotAfter={dolbyVisionMkvLabel} />
+				<Item className={css.infoItem} label="Video Codecs" slotAfter={videoCodecsLabel} />
+				<Item className={css.infoItem} label="Audio Codecs" slotAfter={audioCodecsLabel} />
+				<Item className={css.infoItem} label="Dolby Atmos (EAC3 JOC)" slotAfter={atmosLabel} />
+				<Item className={css.infoItem} label="DTS / TrueHD" slotAfter={hdAudioLabel} />
+				<Item className={css.infoItem} label="Max Audio Channels" slotAfter={maxAudioChannelsLabel} />
+				<Item className={css.infoItem} label="Max Streaming Bitrate" slotAfter={maxStreamingBitrateLabel} />
 			</section>
 
 			<section className={css.section}>

--- a/src/views/settings-panel/constants.js
+++ b/src/views/settings-panel/constants.js
@@ -4,7 +4,7 @@ export const DEFAULT_SETTINGS = {
 	maxBitrate: '40',
 	enableTranscoding: true,
 	forceTranscoding: false,
-	forceTranscodingWithSubtitles: true,
+	forceTranscodingWithSubtitles: false,
 	relaxedPlaybackProfile: false,
 	preferredAudioLanguage: 'eng',
 	preferredSubtitleLanguage: 'eng',
@@ -16,6 +16,7 @@ export const DEFAULT_SETTINGS = {
 	showPlayNextPrompt: true,
 	playNextPromptMode: 'segmentsOrLast60',
 	skipIntro: true,
+	capabilityProbeRefreshDays: '30',
 	showBackdrops: true,
 	showSeasonImages: false,
 	useSidewaysEpisodeList: true,
@@ -59,8 +60,17 @@ export const NAVBAR_THEME_OPTIONS = [
 	{value: 'elegant', label: 'Elegant'}
 ];
 
+export const CAPABILITY_PROBE_REFRESH_OPTIONS = [
+	{value: '7', label: '7 days'},
+	{value: '14', label: '14 days'},
+	{value: '30', label: '30 days (Default)'},
+	{value: '60', label: '60 days'},
+	{value: '90', label: '90 days'}
+];
+
 export const SETTINGS_DISCLOSURE_KEYS = {
 	BITRATE: 'bitratePopup',
+	CAPABILITY_PROBE_REFRESH: 'capabilityProbeRefreshPopup',
 	AUDIO_LANGUAGE: 'audioLanguagePopup',
 	SUBTITLE_LANGUAGE: 'subtitleLanguagePopup',
 	NAVBAR_THEME: 'navbarThemePopup',
@@ -72,6 +82,7 @@ export const SETTINGS_DISCLOSURE_KEYS = {
 
 export const SETTINGS_DISCLOSURE_KEY_LIST = [
 	SETTINGS_DISCLOSURE_KEYS.BITRATE,
+	SETTINGS_DISCLOSURE_KEYS.CAPABILITY_PROBE_REFRESH,
 	SETTINGS_DISCLOSURE_KEYS.AUDIO_LANGUAGE,
 	SETTINGS_DISCLOSURE_KEYS.SUBTITLE_LANGUAGE,
 	SETTINGS_DISCLOSURE_KEYS.NAVBAR_THEME,
@@ -83,6 +94,7 @@ export const SETTINGS_DISCLOSURE_KEY_LIST = [
 
 export const INITIAL_SETTINGS_DISCLOSURES = {
 	[SETTINGS_DISCLOSURE_KEYS.BITRATE]: false,
+	[SETTINGS_DISCLOSURE_KEYS.CAPABILITY_PROBE_REFRESH]: false,
 	[SETTINGS_DISCLOSURE_KEYS.AUDIO_LANGUAGE]: false,
 	[SETTINGS_DISCLOSURE_KEYS.SUBTITLE_LANGUAGE]: false,
 	[SETTINGS_DISCLOSURE_KEYS.NAVBAR_THEME]: false,
@@ -98,6 +110,7 @@ export const DISCLOSURE_BACK_PRIORITY = [
 	SETTINGS_DISCLOSURE_KEYS.LOGOUT_CONFIRM,
 	SETTINGS_DISCLOSURE_KEYS.PLAY_NEXT_PROMPT_MODE,
 	SETTINGS_DISCLOSURE_KEYS.NAVBAR_THEME,
+	SETTINGS_DISCLOSURE_KEYS.CAPABILITY_PROBE_REFRESH,
 	SETTINGS_DISCLOSURE_KEYS.SUBTITLE_LANGUAGE,
 	SETTINGS_DISCLOSURE_KEYS.AUDIO_LANGUAGE,
 	SETTINGS_DISCLOSURE_KEYS.BITRATE

--- a/src/views/settings-panel/labels.js
+++ b/src/views/settings-panel/labels.js
@@ -19,3 +19,9 @@ export const getPlayNextPromptModeLabel = (value) => {
 	}
 };
 
+export const getCapabilityProbeRefreshLabel = (value) => {
+	const days = Number(value);
+	if (!Number.isFinite(days) || days <= 0) return '30 days';
+	if (days === 1) return '1 day';
+	return `${Math.trunc(days)} days`;
+};


### PR DESCRIPTION
Summary:

- Implemented dynamic-range-aware playback routing with capability-driven fallbacks: `DV -> HDR -> SDR`.
- Added webOS-specific DV/HDR compatibility handling (including DV-in-MKV gating by detected device capabilities).
- Hardened audio/subtitle fallback behavior to preserve video dynamic range when possible instead of forcing unnecessary full video transcodes.
- Added runtime capability detection with cache and manual refresh controls, exposed the data in Settings (video/audio/range support info).
- Unified toast behavior/styling across Player, Media Details, and Settings; added playback toasts for quick dynamic-range/play-method verification.
- Episode title in PlayerPanel now includes season and episode numbers, back-return target now changes to the currently playing episode details page.
- Cleanup of old development absolute paths and no longer valid or unnecessary comments.
- Version bump to 0.1.6.