### PR TITLE
fix: Jellyfin 12 compatibility for authentication

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -344,6 +344,10 @@ Jellyfin service paths:
   normalized server base so reverse-proxy prefixes such as `/jellyfin` survive)
 - `src/services/jellyfin/requestErrors.js` (bounded Problem Details parsing and safe
   Jellyfin request errors; raw provider bodies must not be embedded in errors/logs)
+- `src/utils/auth.js` (single source for outbound auth headers, shared by services
+  and login-panel utils; every authenticated request must go through it. Do not reintroduce
+  the legacy `X-Emby-Authorization`/`X-Emby-Token` spellings: 10.x already falls back to
+  the standard `Authorization` header and 12 rejects the old ones)
 - `src/services/jellyfin/homeSectionsApi.js` (opaque Home descriptors/items)
 - `src/services/jellyfin/discoveryApi.js` and `calendarApi.js` (read-only provider data;
   Discovery is surfaced through enabled HSS Home descriptors rather than a standalone tab)

--- a/src/services/__tests__/jellyfinService.test.js
+++ b/src/services/__tests__/jellyfinService.test.js
@@ -99,7 +99,7 @@ describe('jellyfinService', () => {
 		const parsedImageUrl = new URL(imageUrl);
 		expect(parsedImageUrl.origin).toBe('http://media.local');
 		expect(parsedImageUrl.pathname).toBe('/Items/item-1/Images/Primary');
-		expect(parsedImageUrl.searchParams.get('api_key')).toBe('token-123');
+		expect(parsedImageUrl.searchParams.get('ApiKey')).toBe('token-123');
 		expect(parsedImageUrl.searchParams.get('width')).toBe('320');
 		expect(parsedImageUrl.searchParams.get('tag')).toBe('tag-1');
 		expect(parsedImageUrl.searchParams.get('format')).toBe('Jpg');
@@ -129,7 +129,7 @@ describe('jellyfinService', () => {
 
 		expect(parsedImageUrl.origin).toBe('http://media.local');
 		expect(parsedImageUrl.pathname).toBe('/Users/user-1/Images/Primary');
-		expect(parsedImageUrl.searchParams.get('api_key')).toBe('token-123');
+		expect(parsedImageUrl.searchParams.get('ApiKey')).toBe('token-123');
 		expect(parsedImageUrl.searchParams.get('width')).toBe('96');
 		expect(parsedImageUrl.searchParams.has('tag')).toBe(false);
 	});
@@ -173,12 +173,12 @@ describe('jellyfinService', () => {
 				expect.objectContaining({
 					method: 'POST',
 					headers: expect.objectContaining({
-						'X-Emby-Authorization': expect.stringContaining(`DeviceId="${jellyfinService.getDeviceId()}"`)
+						'Authorization': expect.stringContaining(`DeviceId="${jellyfinService.getDeviceId()}"`)
 					}),
 					body: JSON.stringify({Username: 'Alice', Pw: 'secret'})
 				})
 			);
-			const authHeader = global.fetch.mock.calls[0]?.[1]?.headers?.['X-Emby-Authorization'] || '';
+			const authHeader = global.fetch.mock.calls[0]?.[1]?.headers?.Authorization || '';
 			expect(authHeader).toContain('Version="9.9.9"');
 			expect(resolveClientVersionSpy).toHaveBeenCalledTimes(1);
 			expect(getClientVersionSpy).toHaveBeenCalled();

--- a/src/services/__tests__/playbackApi.test.js
+++ b/src/services/__tests__/playbackApi.test.js
@@ -223,7 +223,7 @@ describe('playbackApi', () => {
 		const parsed = new URL(url);
 		expect(parsed.origin).toBe('http://media.local');
 		expect(parsed.pathname).toBe('/Videos/item-1/stream');
-		expect(parsed.searchParams.get('api_key')).toBe('token-1');
+		expect(parsed.searchParams.get('ApiKey')).toBe('token-1');
 		expect(parsed.searchParams.get('static')).toBe('true');
 		expect(parsed.searchParams.get('container')).toBe('mp4');
 		expect(parsed.searchParams.get('mediaSourceId')).toBe('source-1');

--- a/src/services/__tests__/pluginFeaturesApi.test.js
+++ b/src/services/__tests__/pluginFeaturesApi.test.js
@@ -208,7 +208,7 @@ describe('plugin feature APIs', () => {
 		expect(imageUrl.origin).toBe(service.serverUrl);
 		expect(imageUrl.pathname).toBe('/Breezyfin/ExternalImages/signed');
 		expect(imageUrl.searchParams.get('width')).toBe('500');
-		expect(imageUrl.searchParams.get('api_key')).toBe(service.accessToken);
+		expect(imageUrl.searchParams.get('ApiKey')).toBe(service.accessToken);
 	});
 
 	it.each([
@@ -224,7 +224,7 @@ describe('plugin feature APIs', () => {
 
 		expect(imageUrl.pathname).toBe(expectedPath);
 		expect(imageUrl.searchParams.get('width')).toBe('640');
-		expect(imageUrl.searchParams.get('api_key')).toBe('secret');
+		expect(imageUrl.searchParams.get('ApiKey')).toBe('secret');
 	});
 
 	it('rejects malformed plugin image context', () => {

--- a/src/services/__tests__/sessionApi.test.js
+++ b/src/services/__tests__/sessionApi.test.js
@@ -130,7 +130,7 @@ describe('sessionApi', () => {
 			PrimaryImageTag: 'avatar-1'
 		});
 
-		const authHeader = global.fetch.mock.calls[0]?.[1]?.headers?.['X-Emby-Authorization'] || '';
+		const authHeader = global.fetch.mock.calls[0]?.[1]?.headers?.Authorization || '';
 		expect(authHeader).toContain('Version="3.4.5"');
 		expect(authHeader).toContain('DeviceId="service-device-id"');
 		expect(service.resolveClientVersion).toHaveBeenCalledTimes(1);

--- a/src/services/__tests__/subtitleApi.test.js
+++ b/src/services/__tests__/subtitleApi.test.js
@@ -27,7 +27,7 @@ describe('subtitleApi', () => {
 			serverUrl: 'https://jellyfin.example',
 			accessToken: 'token'
 		}, 'item-1', 'source-1', 3, 'ass')).toBe(
-			'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/Stream.ass?api_key=token'
+			'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/Stream.ass?ApiKey=token'
 		);
 	});
 
@@ -39,7 +39,7 @@ describe('subtitleApi', () => {
 			serverUrl: 'https://jellyfin.example',
 			accessToken: 'token'
 		}, 'item-1', 'source-1', 3, 'pgs')).toBe(
-			'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.pgs?api_key=token'
+			'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.pgs?ApiKey=token'
 		);
 	});
 
@@ -96,7 +96,7 @@ describe('subtitleApi', () => {
 			'/Videos/item-1/source-1/Subtitles/4/0/Stream.pgssub'
 		]);
 		expect(result.candidates[0].url).toBe(
-			'https://jellyfin.example/Videos/item-1/source-1/Subtitles/4/0/Stream.sup?api_key=token'
+			'https://jellyfin.example/Videos/item-1/source-1/Subtitles/4/0/Stream.sup?ApiKey=token'
 		);
 	});
 
@@ -208,7 +208,7 @@ describe('subtitleApi', () => {
 			text: 'WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello',
 			format: 'vtt',
 			path: '/Videos/item-1/source-1/Subtitles/3/Stream.vtt',
-			url: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/Stream.vtt?api_key=token',
+			url: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/Stream.vtt?ApiKey=token',
 			contentType: 'text/vtt'
 		}));
 	});
@@ -237,8 +237,8 @@ describe('subtitleApi', () => {
 			data: buffer,
 			format: 'sup',
 			path: '/Videos/item-1/source-1/Subtitles/3/0/Stream.sup',
-			url: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.sup?api_key=token',
-			debugUrl: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.sup?api_key=[REDACTED]',
+			url: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.sup?ApiKey=token',
+			debugUrl: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.sup?ApiKey=[REDACTED]',
 			contentType: 'application/octet-stream',
 			status: 200,
 			failureStage: '',
@@ -328,8 +328,8 @@ describe('subtitleApi', () => {
 				status: 400,
 				failureStage: 'request',
 				path: '/Videos/item-1/source-1/Subtitles/3/0/Stream.sup',
-				url: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.sup?api_key=token',
-				debugUrl: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.sup?api_key=[REDACTED]'
+				url: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.sup?ApiKey=token',
+				debugUrl: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.sup?ApiKey=[REDACTED]'
 			})
 		);
 	});
@@ -351,7 +351,7 @@ describe('subtitleApi', () => {
 				error: 'body read failed',
 				status: 200,
 				failureStage: 'body-read',
-				debugUrl: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.sup?api_key=[REDACTED]'
+				debugUrl: 'https://jellyfin.example/Videos/item-1/source-1/Subtitles/3/0/Stream.sup?ApiKey=[REDACTED]'
 			})
 		);
 	});

--- a/src/services/jellyfin/playback-api/network.js
+++ b/src/services/jellyfin/playback-api/network.js
@@ -1,9 +1,11 @@
+import {buildTokenAuthHeaders} from '../../../utils/auth';
+
 export const fetchPlaybackInfo = async (service, itemId, payload) => {
 	const response = await fetch(`${service.serverUrl}/Items/${itemId}/PlaybackInfo?userId=${service.userId}`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
-			'X-Emby-Token': service.accessToken
+			...buildTokenAuthHeaders(service.accessToken)
 		},
 		body: JSON.stringify(payload)
 	});

--- a/src/services/jellyfin/playbackApi.js
+++ b/src/services/jellyfin/playbackApi.js
@@ -1,3 +1,4 @@
+import {AUTH_QUERY_PARAM} from '../../utils/auth';
 import { getPlaystateApi } from '@jellyfin/sdk/lib/utils/api/playstate-api';
 import {
 	determinePlayMethod,
@@ -1147,7 +1148,7 @@ export const getItemPlaybackInfo = async (service, itemId, options = {}) => {
 export const getPlaybackStreamUrl = (service, itemId, mediaSourceId, playSessionId, tag, container, liveStreamId) => {
 	const params = new URLSearchParams({
 		static: 'true',
-		api_key: service.accessToken
+		[AUTH_QUERY_PARAM]: service.accessToken
 	});
 	if (container) {
 		params.set('container', container);

--- a/src/services/jellyfin/pluginFeaturesApi.js
+++ b/src/services/jellyfin/pluginFeaturesApi.js
@@ -1,3 +1,4 @@
+import {AUTH_QUERY_PARAM} from '../../utils/auth';
 import {
 	getBreezyfinCapabilities,
 	getUnavailablePluginResult,
@@ -63,7 +64,7 @@ export const buildAuthenticatedPluginImageUrl = (service, relativePath, width = 
 		return null;
 	}
 	url.searchParams.set('width', String(safeWidth));
-	url.searchParams.set('api_key', service.accessToken);
+	url.searchParams.set(AUTH_QUERY_PARAM, service.accessToken);
 	return url.toString();
 };
 

--- a/src/services/jellyfin/sessionApi.js
+++ b/src/services/jellyfin/sessionApi.js
@@ -1,6 +1,7 @@
 import serverManager from '../serverManager';
 import {getAppVersion} from '../../utils/appInfo';
 import {getDeviceId} from '../../utils/deviceIdentity';
+import {buildClientAuthHeaders} from '../../utils/auth';
 
 const LEGACY_AUTH_KEY = 'jellyfinAuth';
 
@@ -78,7 +79,7 @@ export const authenticateWithServer = async (service, username, password) => {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
-					'X-Emby-Authorization': `MediaBrowser Client="Breezyfin", Device="webOS", DeviceId="${deviceId}", Version="${appVersion}"`
+					...buildClientAuthHeaders(deviceId, appVersion)
 				},
 				body: JSON.stringify({
 					Username: username,

--- a/src/services/jellyfin/subtitleApi.js
+++ b/src/services/jellyfin/subtitleApi.js
@@ -1,5 +1,6 @@
 import {toInteger} from '../../utils/numberParsing';
 import {redactSensitiveUrl} from '../../utils/sensitiveData';
+import {AUTH_QUERY_PARAM} from '../../utils/auth';
 
 export const BITMAP_SUBTITLE_DELIVERY_FORMATS = ['sup', 'pgs', 'pgssub'];
 
@@ -125,7 +126,7 @@ export const redactSubtitleUrl = (url) => {
 const appendApiKeyToUrl = (url, accessToken) => {
 	if (!url || !accessToken || hasAuthQueryParam(url)) return url || null;
 	const separator = String(url).includes('?') ? '&' : '?';
-	return `${url}${separator}${new URLSearchParams({api_key: accessToken}).toString()}`;
+	return `${url}${separator}${new URLSearchParams({[AUTH_QUERY_PARAM]: accessToken}).toString()}`;
 };
 
 const joinServerUrl = (serverUrl, path) => {

--- a/src/services/jellyfin/websocketApi.js
+++ b/src/services/jellyfin/websocketApi.js
@@ -1,4 +1,5 @@
 import {invalidateWatchlistCache, notifyUserDataInvalidated} from './watchlistApi';
+import {AUTH_QUERY_PARAM} from '../../utils/auth';
 
 const RECONNECT_BASE_DELAY_MS = 1000;
 const RECONNECT_MAX_DELAY_MS = 30000;
@@ -9,7 +10,7 @@ const getSocketUrl = (service) => {
 	base.protocol = base.protocol === 'https:' ? 'wss:' : 'ws:';
 	base.pathname = `${base.pathname.replace(/\/$/, '')}/socket`;
 	base.search = '';
-	base.searchParams.set('api_key', service.accessToken);
+	base.searchParams.set(AUTH_QUERY_PARAM, service.accessToken);
 	base.searchParams.set('deviceId', service.getDeviceId());
 	return base.toString();
 };

--- a/src/services/jellyfinService.js
+++ b/src/services/jellyfinService.js
@@ -50,6 +50,7 @@ import {
 	reportPlaybackStarted,
 	reportPlaybackStoppedState
 } from './jellyfin/playbackApi';
+import {AUTH_QUERY_PARAM, buildTokenAuthHeaders} from '../utils/auth';
 import {getBreezyfinCapabilities, getMyRequestItems} from './jellyfin/requestsApi';
 import {getHomeSectionDescriptors, getHomeSectionItems} from './jellyfin/homeSectionsApi';
 import {getDiscoveryDetails, getDiscoveryFeed} from './jellyfin/discoveryApi';
@@ -170,7 +171,7 @@ class JellyfinService {
 
 	_getAuthHeaders(extraHeaders = {}) {
 		return {
-			'X-Emby-Token': this.accessToken,
+			...buildTokenAuthHeaders(this.accessToken),
 			...extraHeaders
 		};
 	}
@@ -182,7 +183,7 @@ class JellyfinService {
 			if (value === undefined || value === null || value === '') return;
 			search.set(key, String(value));
 		});
-		search.set('api_key', this.accessToken);
+		search.set(AUTH_QUERY_PARAM, this.accessToken);
 		applyPreferredImageFormatToParams(search, options);
 		return `${this.serverUrl}${path}?${search.toString()}`;
 	}

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,17 @@
+const CLIENT_NAME = 'Breezyfin';
+const DEVICE_NAME = 'webOS';
+
+// Jellyfin reads the standard Authorization header on every supported release: 10.x
+// falls back to it when X-Emby-Authorization is absent, and 12 accepts nothing else.
+export const buildClientAuthHeaders = (deviceId, appVersion) => ({
+	Authorization: `MediaBrowser Client="${CLIENT_NAME}", Device="${DEVICE_NAME}", DeviceId="${deviceId}", Version="${appVersion}"`
+});
+
+export const buildTokenAuthHeaders = (accessToken) => ({
+	Authorization: `MediaBrowser Token="${accessToken}"`
+});
+
+// WebSockets and media URLs cannot carry headers, so the token travels as a query
+// parameter there. Only this spelling is read unconditionally; the lowercase
+// `api_key` sits behind the same legacy flag as the X-Emby-* headers.
+export const AUTH_QUERY_PARAM = 'ApiKey';

--- a/src/utils/imageUrls.js
+++ b/src/utils/imageUrls.js
@@ -1,4 +1,5 @@
 import {applyPreferredImageFormatToParams} from './imageFormat';
+import {AUTH_QUERY_PARAM} from './auth';
 
 export const getFirstImageTag = (value) => (
 	Array.isArray(value) && typeof value[0] === 'string' && value[0]
@@ -11,7 +12,7 @@ export const buildItemImageUrl = ({ baseUrl, itemId, imageType, accessToken, wid
 	const normalizedBase = baseUrl.replace(/\/+$/, '');
 	const params = new URLSearchParams({
 		width: String(width),
-		api_key: accessToken
+		[AUTH_QUERY_PARAM]: accessToken
 	});
 	if (tag) {
 		params.set('tag', tag);
@@ -26,7 +27,7 @@ export const buildUserPrimaryImageUrl = ({ baseUrl, userId, accessToken, width, 
 	const normalizedBase = baseUrl.replace(/\/+$/, '');
 	const params = new URLSearchParams({
 		width: String(width),
-		api_key: accessToken
+		[AUTH_QUERY_PARAM]: accessToken
 	});
 	if (tag) {
 		params.set('tag', tag);

--- a/src/views/login-panel/utils/__tests__/loginImageUrls.test.js
+++ b/src/views/login-panel/utils/__tests__/loginImageUrls.test.js
@@ -30,7 +30,7 @@ describe('login image url helpers', () => {
 
 		expect(parsedUrl.origin).toBe('http://media.local');
 		expect(parsedUrl.pathname).toBe('/Users/user-1/Images/Primary');
-		expect(parsedUrl.searchParams.get('api_key')).toBe('token-1');
+		expect(parsedUrl.searchParams.get('ApiKey')).toBe('token-1');
 		expect(parsedUrl.searchParams.get('width')).toBe('88');
 		expect(parsedUrl.searchParams.has('tag')).toBe(false);
 	});

--- a/src/views/login-panel/utils/loginBackdropSources.js
+++ b/src/views/login-panel/utils/loginBackdropSources.js
@@ -1,3 +1,4 @@
+import {buildTokenAuthHeaders} from '../../../utils/auth';
 import {shuffleArray} from '../../../utils/arrayUtils';
 import {
 	LOGIN_BACKDROP_IMAGE_FIELDS,
@@ -28,9 +29,7 @@ export const fetchBackdropsForSavedServer = async (entry, signal) => {
 		const responses = await Promise.all(
 			requestUrls.map((requestUrl) => (
 				fetch(requestUrl, {
-					headers: {
-						'X-Emby-Token': entry.accessToken
-					},
+					headers: buildTokenAuthHeaders(entry.accessToken),
 					signal
 				}).catch(() => null)
 			))
@@ -102,9 +101,7 @@ export const resolveSavedUserBackdrop = async (entry, signal) => {
 	if (!tag) {
 		try {
 			const response = await fetch(`${baseUrl}/Users/${entry.userId}`, {
-				headers: {
-					'X-Emby-Token': entry.accessToken
-				},
+				headers: buildTokenAuthHeaders(entry.accessToken),
 				signal
 			});
 			if (response?.ok) {


### PR DESCRIPTION
# fix: Jellyfin 12 compatibility for authentication

Breezyfin cannot log in against Jellyfin 12. Login fails with
`Unexpected token 'E', "Error proc"... is not valid JSON`, while the same server works
from Infuse and the official Jellyfin clients.

## Cause

Jellyfin 12 reads the legacy auth mechanisms only when the server-side
`EnableLegacyAuthorization` setting is on, and it defaults to off
([`AuthorizationContext.cs`](https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Server.Implementations/Security/AuthorizationContext.cs)):

```csharp
var auth = httpReq.Headers[HeaderNames.Authorization];

if (_configurationManager.Configuration.EnableLegacyAuthorization && string.IsNullOrEmpty(auth))
{
    auth = httpReq.Headers["X-Emby-Authorization"];
}
```

The flag gates `X-Emby-Authorization`, `X-Emby-Token`, `X-MediaBrowser-Token` and the
`api_key` query parameter — everything Breezyfin used. Two things break:

- **Login** is rejected with HTTP 400 before credentials are checked, so it fails
  regardless of the password. Replaying it with invalid credentials shows the
  difference: `Authorization` returns 401 and logs `Invalid username or password
  entered`, while `X-Emby-Authorization` returns 400 with no credential check.
  Breezyfin's log signature matches the latter.
- **The WebSocket** never authenticates. A WebSocket cannot send request headers, so
  the token has to travel as a query parameter, and `api_key` is ignored. The client
  retries `/socket` every 20–40s while the server logs `Token is required`, costing
  remote control, live refresh and SyncPlay.

The JSON parse error is a separate server-side bug: 12.0-rc5's `ExceptionMiddleware`
throws `ArgumentNullException (Parameter 'request.App')` while formatting error
responses and returns plain text instead of JSON. It affects every client and only
hides the real cause here.

## Change

Adds `src/utils/auth.js` as the single definition of outbound auth transport, exporting
the header builders and `AUTH_QUERY_PARAM`.

`Authorization` replaces the `X-Emby-*` headers in `sessionApi.js` (login),
`jellyfinService.js` (`_getAuthHeaders`), `playback-api/network.js` and
`loginBackdropSources.js` (×2). Fixing only the login path is not enough: with a token
in the legacy header alone, libraries and playback still fail.

`ApiKey` replaces `api_key` in `websocketApi.js`, `imageUrls.js` (×2),
`jellyfinService.js`, `subtitleApi.js`, `pluginFeaturesApi.js` and `playbackApi.js`.

Neither replacement is gated, and 10.8/10.10 read both of them *before* the legacy
spellings, so one build stays compatible with 10.x and 12.

Server-supplied `DeliveryUrl` values are left as-is — `hasAuthQueryParam` already
matches every variant. Redaction is unaffected: the patterns in `sensitiveData.js` are
case-insensitive and separator-agnostic, so `ApiKey` is scrubbed like `api_key`. Tests
that assert generated URLs are updated; those using `api_key` to verify secret scrubbing
keep the lowercase spelling.

The helper lives in `src/utils/` rather than `src/services/jellyfin/` because
`loginBackdropSources.js` is a view util and the service-boundary audit forbids views
importing from the service layer. `DEVELOPING.md` documents the module.

## Verification

Branched from `develop`. `npm run lint`,
`npm run test -- --watch=false --runInBand` (121 suites, 717 tests), `npm run audit` and
`npm run pack-p` + `ares-package dist` all pass. Lint reports one pre-existing
`no-trailing-spaces` warning in `usePlayerSeekAndTrackSwitching.js`, untouched by this
change.

Installed on webOS 10.3.1 against Jellyfin 12.0.0: login succeeds,
playback starts, and the WebSocket connects — `Token is required` stops immediately
after the build lands. Verified on both the released 0.2.0 base and this `develop`
build.

Not verified against a Jellyfin 10.x server. That rests on the fallback order in
`AuthorizationContext.cs` for 10.8 and 10.10.
